### PR TITLE
implement graceful handling of malformed registry documents

### DIFF
--- a/tests/pds/registrysweepers/test_ancestry.py
+++ b/tests/pds/registrysweepers/test_ancestry.py
@@ -243,5 +243,40 @@ class AncestryAlternateIdsTestCase(unittest.TestCase):
         self.assertSetEqual(v1_expected_parent_bundle_lidvids, {str(lv) for lv in product_v3.parent_bundle_lidvids})
 
 
+class AncestryMalformedDocsTestCase(unittest.TestCase):
+    input_file_path = os.path.abspath(
+        "./tests/pds/registrysweepers/test_ancestry_mock_AncestryMalformedDocsTestCase.json"
+    )
+    registry_query_mock = RegistryQueryMock(input_file_path)
+
+    ancestry_records: List[AncestryRecord] = []
+    bulk_updates: List[Tuple[str, Dict[str, List]]] = []
+
+    def test_ancestry_completes_without_fatal_error(self):
+        ancestry.run(
+            base_url="",
+            username="",
+            password="",
+            registry_mock_query_f=self.registry_query_mock.get_mocked_query,
+            ancestry_records_accumulator=self.ancestry_records,
+            bulk_updates_sink=self.bulk_updates,
+        )
+
+        self.bundle_records = [r for r in self.ancestry_records if r.lidvid.is_bundle()]
+        self.collection_records = [r for r in self.ancestry_records if r.lidvid.is_collection()]
+        self.nonaggregate_records = [r for r in self.ancestry_records if r.lidvid.is_basic_product()]
+
+        self.records_by_lidvid_str = {str(r.lidvid): r for r in self.ancestry_records}
+        self.bundle_records_by_lidvid_str = {str(r.lidvid): r for r in self.ancestry_records if r.lidvid.is_bundle()}
+        self.collection_records_by_lidvid_str = {
+            str(r.lidvid): r for r in self.ancestry_records if r.lidvid.is_collection()
+        }
+        self.nonaggregate_records_by_lidvid_str = {
+            str(r.lidvid): r for r in self.ancestry_records if r.lidvid.is_basic_product()
+        }
+
+        self.updates_by_lidvid_str = {id: content for id, content in self.bulk_updates}
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/pds/registrysweepers/test_ancestry_mock_AncestryMalformedDocsTestCase.json
+++ b/tests/pds/registrysweepers/test_ancestry_mock_AncestryMalformedDocsTestCase.json
@@ -1,0 +1,92 @@
+{
+  "get_bundle_ancestry_records": [
+    {
+      "_source": {
+        "lidvid": "a:b:c:bundle::1.0"
+      }
+    },
+    {
+      "_source": {
+        "_": "example of record with missing 'lidvid' field"
+      }
+    }
+  ],
+  "get_collection_ancestry_records_bundles": [
+    {
+      "_source": {
+        "lidvid": "a:b:c:bundle::1.0",
+        "ref_lid_collection": [
+          "a:b:c:bundle:lidrefcollection",
+          "a:b:c:bundle:lidvidrefcollection::1.0"
+        ]
+      }
+    },
+    {
+      "_source": {
+        "_": "example of record with missing 'lidvid' field",
+        "ref_lid_collection": [
+          "a:b:c:bundle:lidrefcollection",
+          "a:b:c:bundle:lidvidrefcollection::1.0"
+        ]
+      }
+    },
+    {
+      "_source": {
+        "lidvid": "a:b:c:bundle::1.0",
+        "_": "example of record with missing 'ref_lid_collection' field"
+      }
+    }
+  ],
+  "get_collection_ancestry_records_collections": [
+    {
+      "_source": {
+        "lidvid": "a:b:c:bundle:lidrefcollection::1.0",
+        "alternate_ids": [
+          "a:b:c:bundle:lidrefcollection::1.0",
+          "a:b:c:bundle:lidrefcollection"
+        ]
+      }
+    },
+    {
+      "_source": {
+        "_": "example of record with missing 'lidvid' field",
+        "alternate_ids": [
+          "a:b:c:bundle:lidrefcollection::2.0",
+          "a:b:c:bundle:lidrefcollection"
+        ]
+      }
+    },
+    {
+      "_source": {
+        "lidvid": "a:b:c:bundle:lidrefcollection::1.0",
+        "_": "example of record with missing 'alternate_ids' field"
+      }
+    }
+  ],
+  "get_nonaggregate_ancestry_records": [
+    {
+      "_source": {
+        "collection_lidvid": "a:b:c:bundle:lidrefcollection::1.0",
+        "product_lidvid": [
+          "a:b:c:bundle:lidrefcollection:collectionuniqueproduct::1.0",
+          "a:b:c:bundle:lidrefcollection:collectionsharedproduct::1.0"
+        ]
+      }
+    },
+    {
+      "_source": {
+        "_": "example of record with missing 'collection_lidvid' field",
+        "product_lidvid": [
+          "a:b:c:bundle:lidrefcollection:collectionuniqueproduct::1.0",
+          "a:b:c:bundle:lidrefcollection:collectionsharedproduct::1.0"
+        ]
+      }
+    },
+    {
+      "_source": {
+        "collection_lidvid": "a:b:c:bundle:lidrefcollection::1.0",
+        "_": "example of record with missing 'product_lidvid' field"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 🗒️ Summary
Test against prod db suggests that registry docs cannot be relied upon to be invariably well-formed.  This PR prevents malformed docs from preventing successful execution of sweepers.  Erroneous docs are logged in as helpful a way as we reasonably can.

## ⚙️ Test Data and/or Report
Unit tests pass.  New tests added for malformed documents

## ♻️ Related Issues
fixes #20 