### PR TITLE
add support for legacy data with non-array-typed singleton properties

### DIFF
--- a/src/pds/registrysweepers/ancestry/generation.py
+++ b/src/pds/registrysweepers/ancestry/generation.py
@@ -11,6 +11,7 @@ from pds.registrysweepers.ancestry.queries import get_bundle_ancestry_records_qu
 from pds.registrysweepers.ancestry.queries import get_collection_ancestry_records_bundles_query
 from pds.registrysweepers.ancestry.queries import get_collection_ancestry_records_collections_query
 from pds.registrysweepers.ancestry.queries import get_nonaggregate_ancestry_records_query
+from pds.registrysweepers.utils import coerce_list_type
 from pds.registrysweepers.utils import Host
 from pds.registrysweepers.utils.productidentifiers.factory import PdsProductIdentifierFactory
 from pds.registrysweepers.utils.productidentifiers.pdslid import PdsLid
@@ -101,7 +102,8 @@ def get_collection_ancestry_records(host: Host, registry_db_mock: DbMockTypeDef 
         try:
             bundle_lidvid = PdsLidVid.from_string(doc["_source"]["lidvid"])
             referenced_collection_identifiers = [
-                PdsProductIdentifierFactory.from_string(id) for id in doc["_source"]["ref_lid_collection"]
+                PdsProductIdentifierFactory.from_string(id)
+                for id in coerce_list_type(doc["_source"]["ref_lid_collection"])
             ]
         except (ValueError, KeyError) as err:
             log.warning(

--- a/src/pds/registrysweepers/utils/__init__.py
+++ b/src/pds/registrysweepers/utils/__init__.py
@@ -5,6 +5,7 @@ import json
 import logging
 import urllib.parse
 from argparse import Namespace
+from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Iterable
@@ -222,3 +223,19 @@ def write_updated_docs(host: Host, ids_and_updates: Mapping[str, Dict], index_na
                 log.error("update error (%d): %s", item["status"], str(item["error"]))
     else:
         log.info("bulk updates were successful")
+
+
+def coerce_list_type(db_value: Any) -> List[Any]:
+    """
+    Coerce a non-array-typed legacy db record into a list containing itself as the only element, or return the
+    original argument if it is already an array (list).  This is sometimes necessary to support legacy db records which
+    did not wrap singleton properties in an enclosing array.
+    """
+
+    return (
+        db_value
+        if type(db_value) is list
+        else [
+            db_value,
+        ]
+    )

--- a/tests/pds/registrysweepers/test_ancestry.py
+++ b/tests/pds/registrysweepers/test_ancestry.py
@@ -7,6 +7,9 @@ from typing import Tuple
 
 from pds.registrysweepers import ancestry
 from pds.registrysweepers.ancestry import AncestryRecord
+from pds.registrysweepers.ancestry import get_collection_ancestry_records
+from pds.registrysweepers.utils import Host
+from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
 
 from tests.mocks.registryquerymock import RegistryQueryMock
 
@@ -276,6 +279,29 @@ class AncestryMalformedDocsTestCase(unittest.TestCase):
         }
 
         self.updates_by_lidvid_str = {id: content for id, content in self.bulk_updates}
+
+
+class AncestryLegacyTypesTestCase(unittest.TestCase):
+    input_file_path = os.path.abspath(
+        "./tests/pds/registrysweepers/test_ancestry_mock_AncestryLegacyTypesTestCase.json"
+    )
+    registry_query_mock = RegistryQueryMock(input_file_path)
+
+    def test_collection_refs_parsing(self):
+        host_stub = Host(None, None, None, None, None)
+        query_mock_f = self.registry_query_mock.get_mocked_query
+        collection_ancestry_records = list(get_collection_ancestry_records(host_stub, query_mock_f))
+
+        self.assertEqual(1, len(collection_ancestry_records))
+
+        expected_collection_lidvid = PdsLidVid.from_string("a:b:c:bundle:lidrefcollection::1.0")
+        expected_parent_bundle_lidvid = PdsLidVid.from_string("a:b:c:bundle::1.0")
+        expected_record = AncestryRecord(
+            lidvid=expected_collection_lidvid,
+            parent_collection_lidvids=set(),
+            parent_bundle_lidvids={expected_parent_bundle_lidvid},
+        )
+        self.assertEqual(expected_record, collection_ancestry_records[0])
 
 
 if __name__ == "__main__":

--- a/tests/pds/registrysweepers/test_ancestry_mock_AncestryLegacyTypesTestCase.json
+++ b/tests/pds/registrysweepers/test_ancestry_mock_AncestryLegacyTypesTestCase.json
@@ -1,0 +1,21 @@
+{
+  "get_collection_ancestry_records_bundles": [
+    {
+      "_source": {
+        "lidvid": "a:b:c:bundle::1.0",
+        "ref_lid_collection": "a:b:c:bundle:lidrefcollection"
+      }
+    }
+  ],
+  "get_collection_ancestry_records_collections": [
+    {
+      "_source": {
+        "lidvid": "a:b:c:bundle:lidrefcollection::1.0",
+        "alternate_ids": [
+          "a:b:c:bundle:lidrefcollection::1.0",
+          "a:b:c:bundle:lidrefcollection"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 🗒️ Summary
Previously, single-string properties were stored in db as strings, not arrays containing single strings.  This was not accounted for in the initial ancestry implementation.  This PR adds support for such data. 

## ⚙️ Test Data and/or Report
Functional tests pass.  New unit testcase added for this requirement

## ♻️ Related Issues
fixes #19 