### PR TITLE
implement chunking for utils.write_updated_docs()

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package provides supplementary metadata generation for registry documents, 
 The provenance sweeper generates metadata for linking each version-superseded product with the versioned product which supersedes it.  The value of the successor is stored in the `ops:Provenance/ops:superseded_by` property.  This property will not be set for the latest version of any product.
 
 #### [Ancestry](https://github.com/NASA-PDS/registry-sweepers/blob/main/src/pds/registrysweepers/ancestry/__init__.py)
-The ancestry sweeper generates membership metadata for each product, i.e. which bundle lidvids and which collection lidvids reference a given product. These values will be stored in properties `ops:Provenance/ops:parent_bundle_identifier` and `ops:Provenance/ops:parent_collection_identifier`, respectively.  
+The ancestry sweeper generates membership metadata for each product, i.e. which bundle lidvids and which collection lidvids reference a given product. These values will be stored in properties `ops:Provenance/ops:parent_bundle_identifier` and `ops:Provenance/ops:parent_collection_identifier`, respectively.
 
 ## Developer Quickstart
 


### PR DESCRIPTION
necessary to prevent choking on prod-scale data

## 🗒️ Summary
During bulk update statement generation, generated statements are now written to db periodically after reaching a threshold of 10k statements.

## ⚙️ Test Data and/or Report
Tests pass.  Manually tested E2E against production database.

## ♻️ Related Issues
fixes #28


