### PR TITLE
32 http retries and error logging/handling improvements

### DIFF
--- a/docker/sweepers_driver.py
+++ b/docker/sweepers_driver.py
@@ -58,10 +58,11 @@ import functools
 import json
 import logging
 import os
+from datetime import datetime
 from typing import Callable, Iterable
 
 from pds.registrysweepers import provenance, ancestry
-from pds.registrysweepers.utils import configure_logging
+from pds.registrysweepers.utils import configure_logging, get_human_readable_elapsed_since
 
 configure_logging(filepath=None, log_level=logging.INFO)
 log = logging.getLogger(__name__)
@@ -126,6 +127,7 @@ run_ancestry = run_factory(ancestry.run)
 
 cross_cluster_remote_node_batches = parse_cross_cluster_remotes(os.environ.get("PROV_REMOTES"))
 log.info('Running sweepers')
+execution_begin = datetime.now()
 if cross_cluster_remote_node_batches is None:
     log.info('No CCS remotes specified - running sweepers against base OpenSearch endpoint only')
     run_provenance()
@@ -139,4 +141,4 @@ else:
         run_ancestry(cross_cluster_remotes=cross_cluster_remotes)
         log.info(f'Successfully ran sweepers against base OpenSearch and {targets_msg_str}')
 
-log.info(f'All sweepers ran successfully successfully!')
+log.info(f'Sweepers successfully executed in {get_human_readable_elapsed_since(execution_begin)}')

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
 [options]
 install_requires =
     requests~=2.28
+    retry~=0.9.2
 
 
 # Change this to False if you use things like __file__ or __path__—which you
@@ -58,6 +59,7 @@ dev =
     sphinx-rtd-theme
     tox
     types_requests~=2.28
+    types-retry~=0.9.9.4
     types-setuptools
 
 [options.entry_points]

--- a/src/pds/registrysweepers/utils/__init__.py
+++ b/src/pds/registrysweepers/utils/__init__.py
@@ -5,6 +5,7 @@ import json
 import logging
 import urllib.parse
 from argparse import Namespace
+from datetime import datetime
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -277,3 +278,11 @@ def coerce_list_type(db_value: Any) -> List[Any]:
             db_value,
         ]
     )
+
+
+def get_human_readable_elapsed_since(begin: datetime) -> str:
+    elapsed_seconds = (datetime.now() - begin).total_seconds()
+    h = int(elapsed_seconds / 3600)
+    m = int(elapsed_seconds % 3600 / 60)
+    s = int(elapsed_seconds % 60)
+    return (f"{h}h" if h else "") + (f"{m}m" if m else "") + f"{s}s"


### PR DESCRIPTION
## 🗒️ Summary
 - HTTP calls are now subject to retry with backoff (2/4/8sec each call)
 - db write errors are now logged as `WARNING` if expected, or `ERROR` if unexpected.  `ERROR` should be flagged for action in CloudWatch Alarms @sjoshi-jpl 
 - elapsed time is now displayed in logs at end of execution, for ease of use

## ⚙️ Test Data and/or Report
Unit tests pass, manually tested against prod

## ♻️ Related Issues
fixes #32 


