### PR TITLE
34 43 remove broken cross-cluster remotes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ When run against the production OpenSearch instance with ~1.1M products, no cros
 
 The overwhelming bottleneck ops are the O(docs_count) db writes in ancestry.
 
-When run on an 8vCPU, 56GB RAM ECS node, the runtime is significantly longer due to the presence of CCR nodes.  Performance has not been benchmarked properly in this context due to the presence of errors preventing actual writes, but in that test, execution time was 1h15m.  CPU utilization stayed at/below 1vCPU and memory utilization peaked at ~14GB.
-
 
 ## Code of Conduct
 

--- a/src/pds/registrysweepers/ancestry/__init__.py
+++ b/src/pds/registrysweepers/ancestry/__init__.py
@@ -28,7 +28,6 @@ def run(
     base_url: str,
     username: str,
     password: str,
-    cross_cluster_remotes=None,
     verify_host_certs: bool = True,
     log_filepath: Union[str, None] = None,
     log_level: int = logging.INFO,
@@ -40,7 +39,7 @@ def run(
 
     log.info("Starting ancestry sweeper")
 
-    host = Host(cross_cluster_remotes or [], password, base_url, username, verify_host_certs)
+    host = Host([], password, base_url, username, verify_host_certs)
 
     bundle_records = get_bundle_ancestry_records(host, registry_mock_query_f)
     collection_records = list(get_collection_ancestry_records(host, registry_mock_query_f))
@@ -97,7 +96,6 @@ if __name__ == "__main__":
         base_url=args.base_URL,
         username=args.username,
         password=args.password,
-        cross_cluster_remotes=args.cluster_nodes,
         verify_host_certs=not args.insecure,
         log_level=args.log_level,
         log_filepath=args.log_file,

--- a/src/pds/registrysweepers/ancestry/__init__.py
+++ b/src/pds/registrysweepers/ancestry/__init__.py
@@ -39,7 +39,7 @@ def run(
 
     log.info("Starting ancestry sweeper")
 
-    host = Host([], password, base_url, username, verify_host_certs)
+    host = Host(password, base_url, username, verify_host_certs)
 
     bundle_records = get_bundle_ancestry_records(host, registry_mock_query_f)
     collection_records = list(get_collection_ancestry_records(host, registry_mock_query_f))

--- a/src/pds/registrysweepers/provenance.py
+++ b/src/pds/registrysweepers/provenance.py
@@ -39,16 +39,13 @@
 # It is important to note that the document is updated, not any dependent
 # index.
 #
-import json
 import logging
-import urllib.parse
 from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Mapping
 from typing import Union
 
-import requests
 from pds.registrysweepers.utils import _vid_as_tuple_of_int
 from pds.registrysweepers.utils import configure_logging
 from pds.registrysweepers.utils import get_extant_lidvids
@@ -65,7 +62,6 @@ def run(
     base_url: str,
     username: str,
     password: str,
-    cross_cluster_remotes=None,
     verify_host_certs: bool = True,
     log_filepath: Union[str, None] = None,
     log_level: int = logging.INFO,
@@ -74,7 +70,7 @@ def run(
 
     log.info("starting CLI processing")
 
-    host = Host(cross_cluster_remotes or [], password, base_url, username, verify_host_certs)
+    host = Host([], password, base_url, username, verify_host_certs)
 
     extant_lidvids = get_extant_lidvids(host)
     successors = get_successors_by_lidvid(extant_lidvids)
@@ -138,9 +134,6 @@ if __name__ == "__main__":
 
       registrysweepers.py --help
 
-    - command for opensearch running in a cluster
-
-      registrysweepers.py -b https://search.us-west-2.es.amazonaws.com -c remote1 remote2 remote3 remote4 -u admin -p admin
     """
 
     args = parse_args(description=cli_description, epilog=cli_epilog)
@@ -149,7 +142,6 @@ if __name__ == "__main__":
         base_url=args.base_URL,
         username=args.username,
         password=args.password,
-        cross_cluster_remotes=args.cluster_nodes,
         verify_host_certs=not args.insecure,
         log_level=args.log_level,
         log_filepath=args.log_file,

--- a/src/pds/registrysweepers/provenance.py
+++ b/src/pds/registrysweepers/provenance.py
@@ -70,7 +70,7 @@ def run(
 
     log.info("starting CLI processing")
 
-    host = Host([], password, base_url, username, verify_host_certs)
+    host = Host(password, base_url, username, verify_host_certs)
 
     extant_lidvids = get_extant_lidvids(host)
     successors = get_successors_by_lidvid(extant_lidvids)

--- a/src/pds/registrysweepers/utils/__init__.py
+++ b/src/pds/registrysweepers/utils/__init__.py
@@ -114,7 +114,7 @@ def query_registry_db(
     log.info(f"Initiating query: {req_content}")
 
     path = f"{index_name}/_search?scroll={scroll_keepalive_minutes}m"
-    
+
     served_hits = 0
 
     last_info_log_at_percentage = 0

--- a/tests/pds/registrysweepers/test_ancestry.py
+++ b/tests/pds/registrysweepers/test_ancestry.py
@@ -288,7 +288,7 @@ class AncestryLegacyTypesTestCase(unittest.TestCase):
     registry_query_mock = RegistryQueryMock(input_file_path)
 
     def test_collection_refs_parsing(self):
-        host_stub = Host(None, None, None, None, None)
+        host_stub = Host(None, None, None, None)
         query_mock_f = self.registry_query_mock.get_mocked_query
         collection_ancestry_records = list(get_collection_ancestry_records(host_stub, query_mock_f))
 


### PR DESCRIPTION
## 🗒️ Summary
Removes all concept of cross-cluster-search remotes from the codebase.  This functionality never worked and as reimplementation is not a priority, better that it's gone completely until/unless reimplementation is planned.

## ⚙️ Test Data and/or Report
Unit tests pass.  E2E tested against prod.  Should be backward-compatible when deployed in AWS but we'll know soon enough if it isn't.

## ♻️ Related Issues
fixes #34 
fixes #43
supersedes #41 
