### PR TITLE
46 bulk flush tuning

### DIFF
--- a/src/pds/registrysweepers/utils/__init__.py
+++ b/src/pds/registrysweepers/utils/__init__.py
@@ -3,6 +3,7 @@ import collections
 import functools
 import json
 import logging
+import sys
 import urllib.parse
 from argparse import Namespace
 from datetime import datetime
@@ -210,24 +211,32 @@ def write_updated_docs(host: Host, ids_and_updates: Mapping[str, Dict], index_na
     """
     Given an OpenSearch host and a mapping of doc ids onto updates to those docs, write bulk updates to documents in db.
     """
-    log.info("Bulk update %d documents", len(ids_and_updates))
-    bulk_update_chunk_threshold = 10000  # threshold is statements count.  There are two products per statement
-    bulk_update_products_threshold = int(bulk_update_chunk_threshold / 2)
+    log.info(f"Updating documents for {len(ids_and_updates)} products...")
 
-    bulk_updates: List[str] = []
+    bulk_buffer_max_size_mb = 20.0
+    bulk_buffer_size_mb = 0.0
+    bulk_updates_buffer: List[str] = []
     for lidvid, update_content in ids_and_updates.items():
-        if len(bulk_updates) >= bulk_update_chunk_threshold:
+        if bulk_buffer_size_mb > bulk_buffer_max_size_mb:
+            pending_product_count = int(len(bulk_updates_buffer) / 2)
             log.info(
-                f"Bulk update chunk threshold reached ({bulk_update_chunk_threshold} statements, {bulk_update_products_threshold} products), writing chunk to db..."
+                f"Bulk update buffer has reached {bulk_buffer_max_size_mb}MB threshold - writing {pending_product_count} document updates to db..."
             )
-            _write_bulk_updates_chunk(host, index_name, bulk_updates)
-            bulk_updates = []
-        bulk_updates.append(json.dumps({"update": {"_id": lidvid}}))
-        bulk_updates.append(json.dumps({"doc": update_content}))
+            _write_bulk_updates_chunk(host, index_name, bulk_updates_buffer)
+            bulk_updates_buffer = []
+            bulk_buffer_size_mb = 0.0
 
-    remaining_products_to_write_count = int(len(bulk_updates) / 2)
-    log.info(f"Writing updates for {remaining_products_to_write_count} remaining products to db...")
-    _write_bulk_updates_chunk(host, index_name, bulk_updates)
+        update_objs = [{"update": {"_id": lidvid}}, {"doc": update_content}]
+        updates_strs = [json.dumps(obj) for obj in update_objs]
+
+        for s in updates_strs:
+            bulk_buffer_size_mb += sys.getsizeof(s) / 1024**2
+
+        bulk_updates_buffer.extend(updates_strs)
+
+    remaining_products_to_write_count = int(len(bulk_updates_buffer) / 2)
+    log.info(f"Writing documents updates for {remaining_products_to_write_count} remaining products to db...")
+    _write_bulk_updates_chunk(host, index_name, bulk_updates_buffer)
 
 
 @retry(exceptions=(HTTPError, RuntimeError), tries=4, delay=2, backoff=2, logger=log)


### PR DESCRIPTION
## 🗒️ Summary
Previously, the `_bulk` API updates were flushed based on number of updates.  This has been replaced with a memory threshold of 20MB instead.

I also renamed the scroll variable because it's misleading to anyone not already familiar with exactly how that works.

## ⚙️ Test Data and/or Report
Tested at 5MB, 10MB, 15MB, 20MB, 40MB.  Negligible performance increase observed above 20MB in current configuration (prod AWS Opensearch, from local dev machine).


## ♻️ Related Issues
fixes #46 