### PR TITLE
improve repairkit sweeper performance

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,25 +42,25 @@ python_requires = >= 3.9
 
 [options.extras_require]
 dev =
-    black
-    flake8
-    flake8-bugbear
-    flake8-docstrings
-    pep8-naming
-    mypy
-    pydocstyle
-    coverage
-    pytest
-    pytest-cov
-    pytest-watch
-    pytest-xdist
-    pre-commit
-    sphinx
-    sphinx-rtd-theme
-    tox
+    black~=23.7.0
+    flake8~=6.1.0
+    flake8-bugbear~=23.7.10
+    flake8-docstrings~=1.7.0
+    pep8-naming~=0.13.3
+    mypy~=1.5.1
+    pydocstyle~=6.3.0
+    coverage~=7.3.0
+    pytest~=7.4.0
+    pytest-cov~=4.1.0
+    pytest-watch~=4.2.0
+    pytest-xdist~=3.3.1
+    pre-commit~=3.3.3
+    sphinx~=3.2.1
+    sphinx-rtd-theme~=0.5.0
+    tox~=4.11.0
     types_requests~=2.28
     types-retry~=0.9.9.4
-    types-setuptools
+    types-setuptools~=68.1.0.0
 
 [options.entry_points]
 # Put your entry point scripts here

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ dev =
     types_requests~=2.28
     types-retry~=0.9.9.4
     types-setuptools~=68.1.0.0
+    Jinja2<3.1
 
 [options.entry_points]
 # Put your entry point scripts here

--- a/src/pds/registrysweepers/ancestry/__init__.py
+++ b/src/pds/registrysweepers/ancestry/__init__.py
@@ -1,11 +1,11 @@
 import logging
 from itertools import chain
-from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Optional
+from typing import Set
 from typing import Tuple
 from typing import Union
 
@@ -16,7 +16,8 @@ from pds.registrysweepers.ancestry.generation import get_nonaggregate_ancestry_r
 from pds.registrysweepers.utils import configure_logging
 from pds.registrysweepers.utils import Host
 from pds.registrysweepers.utils import parse_args
-from pds.registrysweepers.utils import write_updated_docs_legacy
+from pds.registrysweepers.utils import Update
+from pds.registrysweepers.utils import write_updated_docs
 
 log = logging.getLogger(__name__)
 
@@ -46,9 +47,26 @@ def run(
     nonaggregate_records = get_nonaggregate_ancestry_records(host, collection_records, registry_mock_query_f)
 
     ancestry_records = chain(bundle_records, collection_records, nonaggregate_records)
+    updates = generate_updates(ancestry_records, ancestry_records_accumulator, bulk_updates_sink)
+
+    if bulk_updates_sink is None:
+        log.info("Writing bulk updates to database...")
+        write_updated_docs(host, updates)
+    else:
+        # consume generator to dump bulk updates to sink
+        for _ in updates:
+            pass
+
+    log.info("Ancestry sweeper processing complete!")
+
+
+def generate_updates(
+    ancestry_records: Iterable[AncestryRecord], ancestry_records_accumulator=None, bulk_updates_sink=None
+) -> Iterable[Update]:
+    updates: Set[str] = set()
 
     log.info("Generating document bulk updates for AncestryRecords...")
-    updates: Dict[str, Dict[str, Any]] = {}
+
     for record in ancestry_records:
         # Tee the stream of records into the accumulator, if one was provided (functional testing).
         if ancestry_records_accumulator is not None:
@@ -58,29 +76,23 @@ def run(
             log.warning(f"Collection {record.lidvid} is not referenced by any bundle.")
 
         doc_id = str(record.lidvid)
-        update = {
+        update_content = {
             METADATA_PARENT_BUNDLE_KEY: [str(id) for id in record.parent_bundle_lidvids],
             METADATA_PARENT_COLLECTION_KEY: [str(id) for id in record.parent_collection_lidvids],
         }
 
         # Tee the stream of bulk update KVs into the accumulator, if one was provided (functional testing).
         if bulk_updates_sink is not None:
-            bulk_updates_sink.append((doc_id, update))
+            bulk_updates_sink.append((doc_id, update_content))
 
         if doc_id in updates:
-            existing_update = updates[doc_id]
             log.error(
-                f"Multiple updates detected for doc_id {doc_id} - cannot create update! (got {update}, {existing_update} already exists)"
+                f"Multiple updates detected for doc_id {doc_id} - cannot create update! (new content {update_content} will not be written)"
             )
             continue
 
-        updates[doc_id] = update
-
-    if updates and bulk_updates_sink is None:
-        log.info("Writing bulk updates to database...")
-        write_updated_docs_legacy(host, updates)
-
-    log.info("Ancestry sweeper processing complete!")
+        updates.add(doc_id)
+        yield Update(id=doc_id, content=update_content)
 
 
 if __name__ == "__main__":

--- a/src/pds/registrysweepers/ancestry/__init__.py
+++ b/src/pds/registrysweepers/ancestry/__init__.py
@@ -16,7 +16,7 @@ from pds.registrysweepers.ancestry.generation import get_nonaggregate_ancestry_r
 from pds.registrysweepers.utils import configure_logging
 from pds.registrysweepers.utils import Host
 from pds.registrysweepers.utils import parse_args
-from pds.registrysweepers.utils import write_updated_docs
+from pds.registrysweepers.utils import write_updated_docs_legacy
 
 log = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ def run(
 
     if updates and bulk_updates_sink is None:
         log.info("Writing bulk updates to database...")
-        write_updated_docs(host, updates)
+        write_updated_docs_legacy(host, updates)
 
     log.info("Ancestry sweeper processing complete!")
 

--- a/src/pds/registrysweepers/provenance.py
+++ b/src/pds/registrysweepers/provenance.py
@@ -51,7 +51,7 @@ from pds.registrysweepers.utils import configure_logging
 from pds.registrysweepers.utils import get_extant_lidvids
 from pds.registrysweepers.utils import Host
 from pds.registrysweepers.utils import parse_args
-from pds.registrysweepers.utils import write_updated_docs
+from pds.registrysweepers.utils import write_updated_docs_legacy
 
 log = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ def run(
     updates = {id: {METADATA_SUCCESSOR_KEY: successor} for id, successor in successors.items()}
 
     if updates:
-        write_updated_docs(host, updates)
+        write_updated_docs_legacy(host, updates)
 
     log.info("completed CLI processing")
 

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -12,7 +12,7 @@ from typing import Union
 from pds.registrysweepers.utils import configure_logging
 from pds.registrysweepers.utils import Host
 from pds.registrysweepers.utils import query_registry_db
-from pds.registrysweepers.utils import write_updated_docs
+from pds.registrysweepers.utils import write_updated_docs_legacy
 
 from . import allarrays
 
@@ -68,5 +68,5 @@ def run(
                         repairs.update(func(src, fieldname))
         if repairs:
             log.info(f"Writing repairs to document: {id}")
-            write_updated_docs(host, {id: repairs})
+            write_updated_docs_legacy(host, {id: repairs})
     return

--- a/src/pds/registrysweepers/utils/__init__.py
+++ b/src/pds/registrysweepers/utils/__init__.py
@@ -259,19 +259,6 @@ def update_as_statements(update: Update) -> Iterable[str]:
     return updates_strs
 
 
-def write_updated_docs_legacy(host: Host, ids_and_updates: Mapping[str, Dict], index_name: str = "registry"):
-    # TODO: switch over calls to this function to new write_updated_docs() and remove this implementation
-    """
-    Given an OpenSearch host and a mapping of doc ids onto updates to those docs, write bulk updates to documents in db.
-    """
-    log.warning(
-        "Use of write_updated_docs_legacy() is deprecated and should be updated to use new implementation of write_updated_docs()"
-    )
-
-    updates = [Update(id=lidvid, content=update_content) for lidvid, update_content in ids_and_updates.items()]
-    write_updated_docs(host, updates, index_name)
-
-
 @retry(exceptions=(HTTPError, RuntimeError), tries=6, delay=2, backoff=2, logger=log)
 def _write_bulk_updates_chunk(host: Host, index_name: str, bulk_updates: Iterable[str]):
     headers = {"Content-Type": "application/x-ndjson"}

--- a/src/pds/registrysweepers/utils/__init__.py
+++ b/src/pds/registrysweepers/utils/__init__.py
@@ -213,7 +213,8 @@ def get_extant_lidvids(host: Host) -> Iterable[str]:
     return map(lambda doc: doc["_source"]["lidvid"], results)
 
 
-def write_updated_docs(host: Host, ids_and_updates: Mapping[str, Dict], index_name: str = "registry"):
+def write_updated_docs_legacy(host: Host, ids_and_updates: Mapping[str, Dict], index_name: str = "registry"):
+    # TODO: switch over calls to this function to new write_updated_docs() and remove this implementation
     """
     Given an OpenSearch host and a mapping of doc ids onto updates to those docs, write bulk updates to documents in db.
     """

--- a/src/pds/registrysweepers/utils/db/update.py
+++ b/src/pds/registrysweepers/utils/db/update.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class Update:
+    """Class representing an ES/OpenSearch database update to a single document"""
+
+    id: str
+    content: Dict


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Improves performance of repairkit by utilizing _bulk write endpoint properly, allowing it to be feasibly run on large nodes.

Implements lazy/generator-compatible handling of updates, which should either improve memory performance outright or facilitate subsequent memory optimisation efforts.

Adds query ids to log messages, allowing disambiguation of progress updates during nested/long-running queries.

Tweaks sweepers-driver, as I've confused the execution order with the factory declaration order like five times.

## ⚙️ Test Data and/or Report
provenance/ancestry tested heuristically - they take slightly-less time compared to pre-change sweepers (minor speedup combined with retention of no-op updates, which are faster than if data were being changed), and small-volume spot tests of documents show presence of correct metadata

ancestry tested with functional tests - passing

repairkit currently untested - need to test against a db with unrepaired data or an ad-hoc local db with unrepaired data to be absolutely certain, though the potential for error is very low and will be easily detectable by comparing initial vs subsequent runs (whether or not writes stop happening after data is fixed)

## ♻️ Related Issues
required for completion of #61 

@jordanpadams @tloubrieu-jpl @sjoshi-jpl I strongly suggest consideration of a metadata flag containing the most-recent version of repairkit or registry-sweepers which has touched a document.  Just iterating over pds-en (resulting in no updates) takes half an hour every time sweepers executes, which could be avoided entirely by filtering the resultset db-side to just those documents which haven't been hit with a current version of repairkit.  I know we've talked about that previously but I don't know if we have a ticket for it yet.

@nutjob4life any smart ideas for how to resolve the version?  Candidates off the top of my head are:

- hardcode a constant value within repairkit, which is best from a performance perspective but problematic due to the potential for devs to miss incrementing it when making changes to repairkit
- resolve the value from the auto-versioned package value, which is nice but probably too slow for deployment given that we're still on 1.1.0
- resolve the value from the environment, perhaps?  I was thinking to use the docker image id, but that's not actually available within a container by default.


