### PR TITLE
hotfix zero-update writes regression

### DIFF
--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -159,8 +159,9 @@ def write_updated_docs(host: Host, updates: Iterable[Update], index_name: str = 
     remaining_products_to_write_count = int(len(bulk_updates_buffer) / 2)
     updated_doc_count += remaining_products_to_write_count
 
-    log.info(f"Writing documents updates for {remaining_products_to_write_count} remaining products to db...")
-    _write_bulk_updates_chunk(host, index_name, bulk_updates_buffer)
+    if len(bulk_updates_buffer) > 0:
+        log.info(f"Writing documents updates for {remaining_products_to_write_count} remaining products to db...")
+        _write_bulk_updates_chunk(host, index_name, bulk_updates_buffer)
 
     log.info(f"Updated documents for {updated_doc_count} total products!")
 


### PR DESCRIPTION
Attempting to write an empty buffer of doc updates to OpenSearch results in  HTTP400 (regression introduced in #62 )

## 🗒️ Summary
Adds a check to only perform a write of a non-full buffer if there's actually something in it

## ⚙️ Test Data and/or Report
Passes the old Mk.2 eyeball
Currently testing in-situ (pending)

## ♻️ Related Issues
fixes #64

