### PR TITLE
ensure repairkit compatibility with large-doc nodes

### DIFF
--- a/src/pds/registrysweepers/ancestry/generation.py
+++ b/src/pds/registrysweepers/ancestry/generation.py
@@ -176,7 +176,7 @@ def get_nonaggregate_ancestry_records(
                 'Failed to parse collection and/or product LIDVIDs from document in index "%s" with id "%s" due to %s: %s',
                 doc.get("_index"),
                 doc.get("_id"),
-                type(err),
+                type(err).__name__,
                 err,
             )
             continue

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -89,10 +89,12 @@ def run(
         }
     }
 
-    all_docs = query_registry_db(client, unprocessed_docs_query, {})
+    # page_size and bulk_chunk_max_update_count constraints are necessary to avoid choking nodes with very-large docs
+    # i.e. ATM and GEO
+    all_docs = query_registry_db(client, unprocessed_docs_query, {}, page_size=1000)
     updates = generate_updates(all_docs, repairkit_version_metadata_key, SWEEPERS_REPAIRKIT_VERSION)
     ensure_index_mapping(client, "registry", repairkit_version_metadata_key, "integer")
-    write_updated_docs(client, updates)
+    write_updated_docs(client, updates, bulk_chunk_max_update_count=20000)
 
     log.info("Repairkit sweeper processing complete!")
 

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -35,7 +35,7 @@ def query_registry_db(
     scroll_keepalive = f"{scroll_keepalive_minutes}m"
     request_timeout = 20
     query_id = get_random_hex_id()  # This is just used to differentiate queries during logging
-    log.info(f"Initiating query with id {query_id}: {query}")
+    log.info(f"Initiating query with id {query_id}: {json.dumps(query)}")
 
     served_hits = 0
 


### PR DESCRIPTION
## 🗒️ Summary
Repairkit hammers OpenSearch with queries requesting many (10k doc) docs, and doc updates.  For nodes with large documents, this can cause errors both on the query side (450MB responses are not viable and cause overflows) and the update side (triggering indexing on 4.5GB of docs every couple of minutes also appears to be non-viable).

This PR implements repairkit-specific constraints to reduce page size, and limit the update throughput.

Logging is also improved significantly.

Of note, repairkit will now log an error at @jordanpadams request if it has to actually do anything, as this represents a failure of node-users to use an up-to-date version of harvest.

## ⚙️ Test Data and/or Report
Unit tests pass.  Tested live against ATM-PROD and GEO-PROD

## ♻️ Related Issues
fixes #61 


