### PR TITLE
78 standardize on python 3.9

### DIFF
--- a/.github/workflows/branch_cicd.yaml
+++ b/.github/workflows/branch_cicd.yaml
@@ -42,7 +42,7 @@ jobs:
                 name: Set up Python 3
                 uses: actions/setup-python@v1
                 with:
-                    python-version: '3.10'
+                    python-version: '3.9'
             -
                 name: 💵 Python Cache
                 uses: actions/cache@v3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@
 # -----
 #
 # We use a slim python-enabled base image.
-FROM python:3.10-slim-bullseye
+FROM python:3.9-slim-bullseye
 
 ENV INSTALL_WORKDIR=/tmp/registry-sweepers
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ url = https://github.com/NASA-PDS/registry-sweepers
 download_url = https://github.com/NASA-PDS/registry-sweepers/releases/
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.9
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
 

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -7,6 +7,7 @@ from typing import Iterable
 from typing import List
 from typing import Mapping
 from typing import Optional
+from typing import Union
 
 from opensearchpy import OpenSearch
 from pds.registrysweepers.utils.db.update import Update
@@ -137,7 +138,7 @@ def write_updated_docs(
     client: OpenSearch,
     updates: Iterable[Update],
     index_name: str = "registry",
-    bulk_chunk_max_update_count: int | None = None,
+    bulk_chunk_max_update_count: Union[int, None] = None,
 ):
     log.info("Updating a lazily-generated collection of product documents...")
     updated_doc_count = 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310, docs, lint
+envlist = py39, docs, lint
 isolated_build = True
 
 [testenv]
@@ -19,6 +19,6 @@ commands=
 skip_install = true
 
 [testenv:dev]
-basepython = python3.10
+basepython = python3.9
 usedevelop = True
 deps = .[dev]


### PR DESCRIPTION
## 🗒️ Summary
#77 used python 3.10 features.  Branch test environment used python 3.10.  This PR rolls back to python 3.9, per PDS standard

## ⚙️ Test Data and/or Report
Branch tests pass, unstable delivery *should* pass now.

## ♻️ Related Issues
fixes #78 


