### PR TITLE
migrate elasticsearch client to opensearch-py for legacy synx sweeper…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,9 @@ install_requires =
     opensearch-py~=2.3.1
     requests~=2.28
     retry~=0.9.2
-    solr-to-es @ git+https://github.com/o19s/solr-to-es@fc758840b07873de0fcaa2ccd675c79bcafc0b99
+    # this is a temporary dependency, we published the repo https://github.com/o19s/solr-to-es to pypi ourselves
+    # until the ticket https://github.com/o19s/solr-to-es/issues/23 is resolved.
+    pds.solr-to-es==0.3.0
 
 
 # Change this to False if you use things like __file__ or __path__—which you

--- a/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Union
 
-import elasticsearch.helpers  # type: ignore
-from elasticsearch import Elasticsearch
+import opensearchpy.helpers
+from opensearchpy import OpenSearch
 from pds.registrysweepers.legacy_registry_sync.opensearch_loaded_product import get_already_loaded_lidvids
 from pds.registrysweepers.legacy_registry_sync.solr_doc_export_to_opensearch import SolrOsWrapperIter
 from pds.registrysweepers.utils import configure_logging
@@ -28,20 +28,14 @@ def create_legacy_registry_index(es_conn=None):
 
 
 def run(
-    base_url: str,
-    username: str,
-    password: str,
-    verify_host_certs: bool = True,
+    client: OpenSearch,
     log_filepath: Union[str, None] = None,
     log_level: int = logging.INFO,
 ):
     """
     Runs the Solr Legacy Registry synchronization with OpenSearch.
 
-    @param base_url: of the OpenSearch service
-    @param username:
-    @param password:
-    @param verify_host_certs:
+    @param client: OpenSearch client from the opensearchpy library
     @param log_filepath:
     @param log_level:
     @return:
@@ -49,19 +43,17 @@ def run(
 
     configure_logging(filepath=log_filepath, log_level=log_level)
 
-    es_conn = Elasticsearch(hosts=base_url, verify_certs=verify_host_certs, http_auth=(username, password))
-
     solr_itr = SlowSolrDocs(SOLR_URL, "*", rows=100)
 
-    create_legacy_registry_index(es_conn=es_conn)
+    create_legacy_registry_index(es_conn=client)
 
     prod_ids = get_already_loaded_lidvids(
-        product_classes=["Product_Context", "Product_Collection", "Product_Bundle"], es_conn=es_conn
+        product_classes=["Product_Context", "Product_Collection", "Product_Bundle"], es_conn=client
     )
 
     es_actions = SolrOsWrapperIter(solr_itr, OS_INDEX, found_ids=prod_ids)
-    for ok, item in elasticsearch.helpers.streaming_bulk(
-        es_conn, es_actions, chunk_size=50, max_chunk_bytes=50000000, max_retries=5, initial_backoff=10
+    for ok, item in opensearchpy.helpers.streaming_bulk(
+        client, es_actions, chunk_size=50, max_chunk_bytes=50000000, max_retries=5, initial_backoff=10
     ):
         if not ok:
             log.error(item)

--- a/src/pds/registrysweepers/legacy_registry_sync/opensearch_loaded_product.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/opensearch_loaded_product.py
@@ -1,6 +1,6 @@
 import os
 
-import elasticsearch  # type: ignore
+import opensearchpy  # type: ignore
 
 # Optional Environment variable  used for the Cross Cluster Search
 # connections aliases. Each element is separated by a ","
@@ -17,8 +17,10 @@ def get_cross_cluster_indices():
     indices = ["registry"]
 
     if CCS_CONN in os.environ:
-        clusters = os.environ[CCS_CONN].split(",")
-        indices.extend([f"{c}:registry" for c in clusters])
+        ccs_conn = os.environ[CCS_CONN]
+        if ccs_conn:
+            clusters = os.environ[CCS_CONN].split(",")
+            indices.extend([f"{c}:registry" for c in clusters])
 
     return indices
 
@@ -43,5 +45,5 @@ def get_already_loaded_lidvids(product_classes=None, es_conn=None):
             dict(match_phrase={prod_class_prop: prod_class}) for prod_class in product_classes
         ]
 
-    prod_id_resp = elasticsearch.helpers.scan(es_conn, index=get_cross_cluster_indices(), query=query, scroll="3m")
+    prod_id_resp = opensearchpy.helpers.scan(es_conn, index=get_cross_cluster_indices(), query=query, scroll="3m")
     return [p["_id"] for p in prod_id_resp]

--- a/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
@@ -115,6 +115,6 @@ class SolrOsWrapperIter:
         while True:
             try:
                 doc = next(self.solr_itr)
-                return self.solrDoc_to_osDoc(doc)
+                return self.solr_doc_to_os_doc(doc)
             except MissingIdentifierError as e:
                 log.warning(str(e))


### PR DESCRIPTION
…. And use a temporary pypi package as a dependency.

<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

1) The migration to using opensearch-py as a client (https://github.com/NASA-PDS/registry-sweepers/pull/72). was not done for the legacy Solr synchronization sweeper. It is now done.
2) Also, one depency was girectly on a github repository (solr-to-es) which is not allowed by pypi. So I published the dependency myself (while waiting for this ticket to be resolved https://github.com/o19s/solr-to-es/issues/23). And I used this dependency in the current project.