### PR TITLE
Add default modification date in legacy registry synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ LOGLEVEL - an integer log level or anycase string matching a python log level li
 DEV_MODE=1  // disables host verification
 ```
 
+With `--legacy-sync` option, you also need the list of the cross-cluster-search node configured to access all the node's OpensSearch domains:
+
+```
+CCS_CONN=naif-prod-ccs,rms-prod,sbnumd-prod-ccs,geo-prod-ccs,atm-prod-ccs,sbnpsi-prod-ccs,ppi-prod-ccs,img-prod-ccs
+```
+
+Use the connection aliases found in the 'Connections' tab of the Engineering Node OpenSearch Domain on AWS.
+
+https://us-west-2.console.aws.amazon.com/aos/home?region=us-west-2#opensearch/domains/en-prod?tabId=ccs
+
 After cloning the repository, and setting the repository root as the current working directory install the package with `pip install -e .`
 
 The wrapper script for the suite of components may be run with `python ./docker/sweepers_driver.py`

--- a/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Union
 

--- a/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
@@ -16,6 +16,8 @@ NODE_FOLDERS = {
     "sbn": "PDS_SBN",
 }
 
+DEFAULT_MODIFICATION_DATE = datetime(1950, 1, 1, 0, 0, 0)
+
 
 class MissingIdentifierError(Exception):
     pass
@@ -108,7 +110,7 @@ class SolrOsWrapperIter:
 
         # add modification date because kibana needs it for its time field
         if "modification_date" not in new_doc["_source"]:
-            new_doc["_source"]["modification_date"] = [datetime(1950, 1, 1, 0, 0, 0)]
+            new_doc["_source"]["modification_date"] = [DEFAULT_MODIFICATION_DATE]
 
         if self.id_field_fun:
             id = self.id_field_fun(doc)


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Because documents without a modification date do not show in kibana since `modification_date` is the timestamp used by Kibana for the `legacy_registry` index.

## ⚙️ Test Data and/or Report
One of the following should be included here:
* Reference to regression test included in code (preferred wherever reasonable)
* Attach test data here + outputs of tests

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Fixes nasa-pds/registry#234


