### PR TITLE
Repairkit expansion fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This package provides supplementary metadata generation for registry documents, 
 
 ### Components
 
+#### [RepairKit](https://github.com/NASA-PDS/registry-sweepers/blob/main/src/pds/registrysweepers/repairkit/__init__.py)
+The repairkit sweeper applies idempotent transformations to targeted subsets of properties, for example ensuring that all properties expected to have array-like values are in fact arrays (as opposed to single-element arrays being flattened to strings during harvest).  Documents are processed based on whether their `ops:Provenance/ops:registry_sweepers_repairkit_version` is up-to-date relative to the sweeper codebase.
+
 #### [Provenance](https://github.com/NASA-PDS/registry-sweepers/blob/main/src/pds/registrysweepers/provenance.py)
 The provenance sweeper generates metadata for linking each version-superseded product with the versioned product which supersedes it.  The value of the successor is stored in the `ops:Provenance/ops:superseded_by` property.  This property will not be set for the latest version of any product.
 

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -5,6 +5,7 @@ are needed in the future. They can be added by updating the REPAIR_TOOLS mapping
 with the new field name and functional requirements. All the additions can then
 be modules with this executable package.
 """
+import collections
 import logging
 import re
 from typing import Dict
@@ -51,6 +52,9 @@ REPAIR_TOOLS = {
 
 log = logging.getLogger(__name__)
 
+# TODO: remove me once applied to prod -- edunn 20231206
+temporary_fix_targets = allarrays.EXCLUDED_PROPERTIES
+
 
 def generate_updates(
     docs: Iterable[Dict], repairkit_version_metadata_key: str, repairkit_version: int
@@ -68,6 +72,10 @@ def generate_updates(
                 if regex(fieldname):
                     for func in funcs:
                         repairs.update(func(src, fieldname))
+
+                # TODO: remove me once applied -- edunn 20231206
+                if fieldname in temporary_fix_targets:
+                    repairs.update(allarrays.apply_reversion_fix(src, fieldname))
 
         document_needed_fixing = len(set(repairs).difference({repairkit_version_metadata_key})) > 0
         if document_needed_fixing and not repair_already_logged_to_error:

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -73,9 +73,9 @@ def generate_updates(
                     for func in funcs:
                         repairs.update(func(src, fieldname))
 
-                # TODO: remove me once applied -- edunn 20231206
-                if fieldname in temporary_fix_targets:
-                    repairs.update(allarrays.apply_reversion_fix(src, fieldname))
+            # TODO: remove me once applied -- edunn 20231206
+            if fieldname in temporary_fix_targets:
+                repairs.update(allarrays.apply_reversion_fix(src, fieldname))
 
         document_needed_fixing = len(set(repairs).difference({repairkit_version_metadata_key})) > 0
         if document_needed_fixing and not repair_already_logged_to_error:

--- a/src/pds/registrysweepers/repairkit/allarrays.py
+++ b/src/pds/registrysweepers/repairkit/allarrays.py
@@ -1,13 +1,33 @@
 """change single strings to array of strings"""
+import json
 import logging
 from typing import Dict
 
 log = logging.getLogger(__name__)
 
+# exclude the following properties from array conversion even if targeted - they are expected to be string-typed
+EXCLUDED_PROPERTIES = {"lid", "vid", "lidvid", "title", "product_class", "_package_id"}
+
 
 def repair(document: Dict, fieldname: str) -> Dict:
+    # don't touch the enumerated exclusions, or any registry-sweepers metadata property
+    if fieldname in EXCLUDED_PROPERTIES or fieldname.startswith("ops:Provenance"):
+        return {}
+
     log.debug(f"checking {fieldname}")
     if isinstance(document[fieldname], str):
         log.debug(f"found string for {fieldname} where it should be an array")
         return {fieldname: [document[fieldname]]}
+    return {}
+
+
+# TODO: remove me once applied to prod -- edunn 20231206
+def apply_reversion_fix(document: Dict, fieldname: str) -> Dict:
+    src_val = document[fieldname]
+    if isinstance(src_val, list) and len(src_val) == 1:
+        return {fieldname: src_val[0]}
+    else:
+        log.error(
+            f'Unexpected situation when applying reversion fix: Expected single-element array, got {src_val}, when targeting "{fieldname}" in {json.dumps(document)}'
+        )
     return {}

--- a/src/pds/registrysweepers/repairkit/versioning.py
+++ b/src/pds/registrysweepers/repairkit/versioning.py
@@ -1,5 +1,5 @@
 # Defines constants used for versioning updated documents with the in-use version of sweepers
 # SWEEPERS_VERSION must be incremented any time sweepers is changed in a way which requires reprocessing of
 # previously-processed data
-SWEEPERS_REPAIRKIT_VERSION = 2
+SWEEPERS_REPAIRKIT_VERSION = 3
 SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY = "ops:Provenance/ops:registry_sweepers_repairkit_version"

--- a/tests/pds/registrysweepers/repairkit/test_allarrays.py
+++ b/tests/pds/registrysweepers/repairkit/test_allarrays.py
@@ -25,6 +25,7 @@ class AllArrays(unittest.TestCase):
             "ops:Provenance/ops:parent_collection_identifier": ["urn:nasa:pds:clementine_lwir_bt:data_flatfield::1.0"],
             "ops:Provenance/ops:parent_bundle_identifier": ["urn:nasa:pds:clementine_lwir_bt::1.0"],
             "ops:Provenance/ops:registry_sweepers_repairkit_version": 2,
+            "ops:Provenance/someStringTypedProp": "someValue",
         }
 
         repairs = {}

--- a/tests/pds/registrysweepers/repairkit/test_allarrays.py
+++ b/tests/pds/registrysweepers/repairkit/test_allarrays.py
@@ -14,6 +14,69 @@ class AllArrays(unittest.TestCase):
         repair = allarrays.repair(src, "apple")
         self.assertEqual({"apple": ["orange"]}, repair)
 
+    def test_exclusion_logic(self):
+        src = {
+            "lid": "urn:nasa:pds:clementine_lwir_bt:data_flatfield:ff034ag.img",
+            "vid": "1.0",
+            "lidvid": "urn:nasa:pds:clementine_lwir_bt:data_flatfield:ff034ag.img::1.0",
+            "title": "Clementine LWIR brightness temperature flat field product: ff034ag.img",
+            "product_class": "Product_Observational",
+            "_package_id": "c0491371-49f8-4e34-9d1c-f94ef1217b57",
+            "ops:Provenance/ops:parent_collection_identifier": ["urn:nasa:pds:clementine_lwir_bt:data_flatfield::1.0"],
+            "ops:Provenance/ops:parent_bundle_identifier": ["urn:nasa:pds:clementine_lwir_bt::1.0"],
+            "ops:Provenance/ops:registry_sweepers_repairkit_version": 2,
+        }
+
+        repairs = {}
+
+        for fieldname in src:
+            if fieldname in allarrays.EXCLUDED_PROPERTIES:
+                repairs.update(allarrays.apply_reversion_fix(src, fieldname))
+
+        self.assertDictEqual({}, repairs, "test that excluded (string-typed) fields do not result in repair changes")
+
+    def test_temporary_reversion_fix(self):
+        # TODO: remove me once applied to prod -- edunn 20231206
+
+        src = {
+            "lid": ["urn:nasa:pds:clementine_lwir_bt:data_flatfield:ff034ag.img"],
+            "vid": ["1.0"],
+            "lidvid": ["urn:nasa:pds:clementine_lwir_bt:data_flatfield:ff034ag.img::1.0"],
+            "title": ["Clementine LWIR brightness temperature flat field product: ff034ag.img"],
+            "product_class": ["Product_Observational"],
+            "_package_id": ["c0491371-49f8-4e34-9d1c-f94ef1217b57"],
+            "someProperty": ["somePropertyValue"],
+            "ops:Provenance/ops:parent_collection_identifier": ["urn:nasa:pds:clementine_lwir_bt:data_flatfield::1.0"],
+            "ops:Provenance/ops:parent_bundle_identifier": ["urn:nasa:pds:clementine_lwir_bt::1.0"],
+            "ops:Provenance/ops:registry_sweepers_repairkit_version": 2,
+        }
+
+        expected = {
+            "lid": "urn:nasa:pds:clementine_lwir_bt:data_flatfield:ff034ag.img",
+            "vid": "1.0",
+            "lidvid": "urn:nasa:pds:clementine_lwir_bt:data_flatfield:ff034ag.img::1.0",
+            "title": "Clementine LWIR brightness temperature flat field product: ff034ag.img",
+            "product_class": "Product_Observational",
+            "_package_id": "c0491371-49f8-4e34-9d1c-f94ef1217b57",
+            "someProperty": ["somePropertyValue"],
+            "ops:Provenance/ops:parent_collection_identifier": ["urn:nasa:pds:clementine_lwir_bt:data_flatfield::1.0"],
+            "ops:Provenance/ops:parent_bundle_identifier": ["urn:nasa:pds:clementine_lwir_bt::1.0"],
+            "ops:Provenance/ops:registry_sweepers_repairkit_version": 2,
+        }
+
+        repairs = {}
+
+        for fieldname in src:
+            if fieldname in allarrays.EXCLUDED_PROPERTIES:
+                repairs.update(allarrays.apply_reversion_fix(src, fieldname))
+
+        src.update(repairs)
+        self.assertDictEqual(
+            expected,
+            src,
+            "test that enumerated string-typed fields are converted back to strings when reversion fix is applied",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 🗒️ Summary
- Adds enumerated list of non-array-typed properties
- Excludes these properties (and all `pds:Provenance/*` properties) from `allarrays` repairkit repair
- Adds temporary reversion repair to convert these properties back to strings
- Adds unit tests for both the exclusion logic, and the temporary repair 

## ⚙️ Test Data and/or Report
Unit tests implemented

## ♻️ Related Issues
Follow-on from #86 #87 


