### PR TITLE
39 - implement ancestry chunking memory optimization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 .*
 
-/venv/
+/venv
+
+/venv39
 
 /docs/
 
@@ -21,3 +23,7 @@
 /tox.ini
 
 /NOTICE.txt
+
+**/*.egg-info
+
+**/*.log

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 # Python build, virtual environments, and buildouts
 .venv
 venv
+venv39
 __pycache__/
 dist/
 build/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The provenance sweeper generates metadata for linking each version-superseded pr
 #### [Ancestry](https://github.com/NASA-PDS/registry-sweepers/blob/main/src/pds/registrysweepers/ancestry/__init__.py)
 The ancestry sweeper generates membership metadata for each product, i.e. which bundle lidvids and which collection lidvids reference a given product. These values will be stored in properties `ops:Provenance/ops:parent_bundle_identifier` and `ops:Provenance/ops:parent_collection_identifier`, respectively.
 
+[Accepts environment variables to tune performance](./src/pds/registrysweepers/ancestry/runtimeconstants.py), primarily trading increased runtime duration for reduced peak memory usage.
+
 ## Developer Quickstart
 
 ### Prerequisites

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ dev =
     sphinx~=3.2.1
     sphinx-rtd-theme~=0.5.0
     tox~=4.11.0
+    types-psutil~=5.9.5
     types_requests~=2.28
     types-retry~=0.9.9.4
     types-setuptools~=68.1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     opensearch-py~=2.3.1
     requests~=2.28
     retry~=0.9.2
+    psutil~=5.9.7
     # this is a temporary dependency, we published the repo https://github.com/o19s/solr-to-es to pypi ourselves
     # until the ticket https://github.com/o19s/solr-to-es/issues/23 is resolved.
     pds.solr-to-es==0.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,8 @@ python_requires = >= 3.9
 
 [options.extras_require]
 dev =
+# later versions of alabaster require sphinx>=3.4
+    alabaster <=0.7.13
     black~=23.7.0
     flake8~=6.1.0
     flake8-bugbear~=23.7.10
@@ -62,6 +64,15 @@ dev =
     pre-commit~=3.3.3
     sphinx~=3.2.1
     sphinx-rtd-theme~=0.5.0
+
+# unclear why the following pins are necessary, but without them, versions dependent on sphinx>=5.0 are installed
+    sphinxcontrib-applehelp==1.0.4
+    sphinxcontrib-devhelp==1.0.2
+    sphinxcontrib-htmlhelp==2.0.1
+    sphinxcontrib-jsmath==1.0.1
+    sphinxcontrib-qthelp==1.0.3
+    sphinxcontrib-serializinghtml==1.1.5
+
     tox~=4.11.0
     types-psutil~=5.9.5
     types_requests~=2.28

--- a/src/pds/registrysweepers/ancestry/ancestryrecord.py
+++ b/src/pds/registrysweepers/ancestry/ancestryrecord.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
+import json
 from dataclasses import dataclass
 from dataclasses import field
+from typing import Callable
 from typing import Set
 
+from pds.registrysweepers.ancestry.typedefs import SerializableAncestryRecordTypeDef
 from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
 
 
@@ -16,3 +21,41 @@ class AncestryRecord:
 
     def __hash__(self):
         return hash(self.lidvid)
+
+    def to_dict(self, sort_lists: bool = True) -> SerializableAncestryRecordTypeDef:
+        list_f: Callable = lambda x: sorted(x) if sort_lists else list(x)
+
+        return {
+            "lidvid": str(self.lidvid),
+            "parent_collection_lidvids": list_f(str(lidvid) for lidvid in self.parent_collection_lidvids),
+            "parent_bundle_lidvids": list_f(str(lidvid) for lidvid in self.parent_bundle_lidvids),
+        }
+
+    @staticmethod
+    def from_dict(d: SerializableAncestryRecordTypeDef) -> AncestryRecord:
+        try:
+            return AncestryRecord(
+                lidvid=PdsLidVid.from_string(d["lidvid"]),  # type: ignore
+                parent_collection_lidvids=set(
+                    PdsLidVid.from_string(lidvid) for lidvid in d["parent_collection_lidvids"]
+                ),
+                parent_bundle_lidvids=set(PdsLidVid.from_string(lidvid) for lidvid in d["parent_bundle_lidvids"]),
+            )
+        except (KeyError, ValueError) as err:
+            raise ValueError(
+                f'Could not parse valid AncestryRecord from provided dict due to "{err.__class__.__name__}: {err}" (got {json.dumps(d)})'
+            )
+
+    def update_with(self, other: AncestryRecord):
+        """
+        Given another AncestryRecord object with the same lidvid, add its parent histories to those of this
+        AncestryRecord.  Used to merge partial histories.
+        """
+
+        if self.lidvid != other.lidvid:
+            raise ValueError(
+                f"lidvid mismatch in call to AncestryRecord.updateWith() (got {other.lidvid}, should be {self.lidvid})"
+            )
+
+        self.parent_bundle_lidvids.update(other.parent_bundle_lidvids)
+        self.parent_collection_lidvids.update(other.parent_collection_lidvids)

--- a/src/pds/registrysweepers/ancestry/generation.py
+++ b/src/pds/registrysweepers/ancestry/generation.py
@@ -1,3 +1,4 @@
+import gc
 import logging
 import os
 import shutil
@@ -295,6 +296,8 @@ def _get_nonaggregate_ancestry_records_with_chunking(
     chunk_size_max = max(chunk_size_max, sys.getsizeof(nonaggregate_ancestry_records_by_lidvid))
     for history_dict in nonaggregate_ancestry_records_by_lidvid.values():
         yield AncestryRecord.from_dict(history_dict)
+    del nonaggregate_ancestry_records_by_lidvid
+    gc.collect()
 
     # merge/yield the disk-dumped records
     remaining_chunk_filepaths = list(os.path.join(on_disk_cache_dir, fn) for fn in os.listdir(on_disk_cache_dir))

--- a/src/pds/registrysweepers/ancestry/generation.py
+++ b/src/pds/registrysweepers/ancestry/generation.py
@@ -290,6 +290,15 @@ def _get_nonaggregate_ancestry_records_with_chunking(
             )
             continue
 
+    # don't forget to yield non-disk-dumped records
+    make_history_serializable(nonaggregate_ancestry_records_by_lidvid)
+    chunk_size_max = max(
+        chunk_size_max, sys.getsizeof(nonaggregate_ancestry_records_by_lidvid)
+    )
+    for history_dict in nonaggregate_ancestry_records_by_lidvid.values():
+        yield AncestryRecord.from_dict(history_dict)
+
+    # merge/yield the disk-dumped records
     remaining_chunk_filepaths = list(os.path.join(on_disk_cache_dir, fn) for fn in os.listdir(on_disk_cache_dir))
     while len(remaining_chunk_filepaths) > 0:
         # use of pop() here is important - see comment in merge_matching_history_chunks() where

--- a/src/pds/registrysweepers/ancestry/generation.py
+++ b/src/pds/registrysweepers/ancestry/generation.py
@@ -271,7 +271,7 @@ def _get_nonaggregate_ancestry_records_with_chunking(
 
                 if psutil.virtual_memory().percent >= disk_dump_memory_threshold:
                     log.info(
-                        f"Memory threshold {disk_dump_memory_threshold}% reached - dumping serialized history to disk for {len(nonaggregate_ancestry_records_by_lidvid)} products"
+                        f"Memory threshold {disk_dump_memory_threshold:.1f}% reached - dumping serialized history to disk for {len(nonaggregate_ancestry_records_by_lidvid)} products"
                     )
                     make_history_serializable(nonaggregate_ancestry_records_by_lidvid)
                     dump_history_to_disk(on_disk_cache_dir, nonaggregate_ancestry_records_by_lidvid)
@@ -298,6 +298,10 @@ def _get_nonaggregate_ancestry_records_with_chunking(
 
     # merge/yield the disk-dumped records
     remaining_chunk_filepaths = list(os.path.join(on_disk_cache_dir, fn) for fn in os.listdir(on_disk_cache_dir))
+    disk_swap_space_utilized_gb = sum(os.stat(filepath).st_size for filepath in remaining_chunk_filepaths) / 1024**3
+    log.info(
+        f"On-disk swap comprised of {len(remaining_chunk_filepaths)} files totalling {disk_swap_space_utilized_gb:.1f}GB"
+    )
     while len(remaining_chunk_filepaths) > 0:
         # use of pop() here is important - see comment in merge_matching_history_chunks() where
         # ancestry.utils.split_chunk_if_oversized() is called, for justification

--- a/src/pds/registrysweepers/ancestry/generation.py
+++ b/src/pds/registrysweepers/ancestry/generation.py
@@ -234,7 +234,7 @@ def _get_nonaggregate_ancestry_records_with_chunking(
         os.makedirs(on_disk_cache_dir, exist_ok=True)
     else:
         on_disk_cache_dir = tempfile.mkdtemp(prefix="ancestry-merge-dump_")
-    log.info(f"dumping partial non-aggregate ancestry result-sets to {on_disk_cache_dir}")
+    log.debug(f"dumping partial non-aggregate ancestry result-sets to {on_disk_cache_dir}")
 
     collection_refs_query_docs = get_nonaggregate_ancestry_records_query(client, registry_db_mock)
 
@@ -270,7 +270,7 @@ def _get_nonaggregate_ancestry_records_with_chunking(
                 record_dict["parent_collection_lidvids"].add(str(collection_lidvid))
 
                 if psutil.virtual_memory().percent >= disk_dump_memory_threshold:
-                    log.info(
+                    log.debug(
                         f"Memory threshold {disk_dump_memory_threshold:.1f}% reached - dumping serialized history to disk for {len(nonaggregate_ancestry_records_by_lidvid)} products"
                     )
                     make_history_serializable(nonaggregate_ancestry_records_by_lidvid)

--- a/src/pds/registrysweepers/ancestry/generation.py
+++ b/src/pds/registrysweepers/ancestry/generation.py
@@ -9,7 +9,7 @@ from typing import List
 from typing import Mapping
 from typing import Set
 
-import psutil
+import psutil  # type: ignore
 from opensearchpy import OpenSearch
 from pds.registrysweepers.ancestry.ancestryrecord import AncestryRecord
 from pds.registrysweepers.ancestry.queries import DbMockTypeDef
@@ -230,7 +230,7 @@ def _get_nonaggregate_ancestry_records_with_chunking(
 
     using_cache_override = bool(os.environ.get("TMP_OVERRIDE_DIR"))
     if using_cache_override:
-        on_disk_cache_dir = os.environ.get("TMP_OVERRIDE_DIR")
+        on_disk_cache_dir: str = os.environ.get("TMP_OVERRIDE_DIR")  # type: ignore
         os.makedirs(on_disk_cache_dir, exist_ok=True)
     else:
         on_disk_cache_dir = tempfile.mkdtemp(prefix="ancestry-merge-dump_")
@@ -265,9 +265,9 @@ def _get_nonaggregate_ancestry_records_with_chunking(
                         "parent_bundle_lidvids": set(),
                     }
 
-                record = nonaggregate_ancestry_records_by_lidvid[nonaggregate_lidvid_str]
-                record["parent_bundle_lidvids"].update({str(id) for id in bundle_ancestry})
-                record["parent_collection_lidvids"].add(str(collection_lidvid))
+                record_dict = nonaggregate_ancestry_records_by_lidvid[nonaggregate_lidvid_str]
+                record_dict["parent_bundle_lidvids"].update({str(id) for id in bundle_ancestry})
+                record_dict["parent_collection_lidvids"].add(str(collection_lidvid))
 
                 if psutil.virtual_memory().percent >= disk_dump_memory_threshold:
                     log.info(
@@ -292,9 +292,7 @@ def _get_nonaggregate_ancestry_records_with_chunking(
 
     # don't forget to yield non-disk-dumped records
     make_history_serializable(nonaggregate_ancestry_records_by_lidvid)
-    chunk_size_max = max(
-        chunk_size_max, sys.getsizeof(nonaggregate_ancestry_records_by_lidvid)
-    )
+    chunk_size_max = max(chunk_size_max, sys.getsizeof(nonaggregate_ancestry_records_by_lidvid))
     for history_dict in nonaggregate_ancestry_records_by_lidvid.values():
         yield AncestryRecord.from_dict(history_dict)
 

--- a/src/pds/registrysweepers/ancestry/queries.py
+++ b/src/pds/registrysweepers/ancestry/queries.py
@@ -7,6 +7,7 @@ from typing import Iterable
 from typing import Optional
 
 from opensearchpy import OpenSearch
+from pds.registrysweepers.ancestry.runtimeconstants import AncestryRuntimeConstants
 from pds.registrysweepers.utils.db import query_registry_db_or_mock
 
 log = logging.getLogger(__name__)
@@ -74,7 +75,7 @@ def get_nonaggregate_ancestry_records_query(client: OpenSearch, registry_db_mock
         query,
         _source,
         index_name="registry-refs",
-        page_size=2000,
+        page_size=AncestryRuntimeConstants.nonaggregate_ancestry_records_query_page_size,
         request_timeout_seconds=30,
         sort_fields=["collection_lidvid", "batch_id"],
     )

--- a/src/pds/registrysweepers/ancestry/queries.py
+++ b/src/pds/registrysweepers/ancestry/queries.py
@@ -35,7 +35,7 @@ def product_class_query_factory(cls: ProductClass) -> Dict:
 def get_bundle_ancestry_records_query(client: OpenSearch, db_mock: DbMockTypeDef = None) -> Iterable[Dict]:
     query = product_class_query_factory(ProductClass.BUNDLE)
     _source = {"includes": ["lidvid"]}
-    query_f = query_registry_db_or_mock(db_mock, "get_bundle_ancestry_records")
+    query_f = query_registry_db_or_mock(db_mock, "get_bundle_ancestry_records", use_search_after=True)
     docs = query_f(client, query, _source)
 
     return docs
@@ -44,7 +44,7 @@ def get_bundle_ancestry_records_query(client: OpenSearch, db_mock: DbMockTypeDef
 def get_collection_ancestry_records_bundles_query(client: OpenSearch, db_mock: DbMockTypeDef = None) -> Iterable[Dict]:
     query = product_class_query_factory(ProductClass.BUNDLE)
     _source = {"includes": ["lidvid", "ref_lid_collection"]}
-    query_f = query_registry_db_or_mock(db_mock, "get_collection_ancestry_records_bundles")
+    query_f = query_registry_db_or_mock(db_mock, "get_collection_ancestry_records_bundles", use_search_after=True)
     docs = query_f(client, query, _source)
 
     return docs
@@ -56,7 +56,7 @@ def get_collection_ancestry_records_collections_query(
     # Query the registry for all collection identifiers
     query = product_class_query_factory(ProductClass.COLLECTION)
     _source = {"includes": ["lidvid", "alternate_ids"]}
-    query_f = query_registry_db_or_mock(db_mock, "get_collection_ancestry_records_collections")
+    query_f = query_registry_db_or_mock(db_mock, "get_collection_ancestry_records_collections", use_search_after=True)
     docs = query_f(client, query, _source)
 
     return docs
@@ -65,8 +65,18 @@ def get_collection_ancestry_records_collections_query(
 def get_nonaggregate_ancestry_records_query(client: OpenSearch, registry_db_mock: DbMockTypeDef) -> Iterable[Dict]:
     # Query the registry-refs index for the contents of all collections
     query: Dict = {"query": {"match_all": {}}}
-    _source = {"includes": ["collection_lidvid", "product_lidvid"]}
-    query_f = query_registry_db_or_mock(registry_db_mock, "get_nonaggregate_ancestry_records")
-    docs = query_f(client, query, _source, index_name="registry-refs")
+    _source = {"includes": ["collection_lidvid", "batch_id", "product_lidvid"]}
+    query_f = query_registry_db_or_mock(registry_db_mock, "get_nonaggregate_ancestry_records", use_search_after=True)
+
+    # each document will have many product lidvids, so a smaller page size is warranted here
+    docs = query_f(
+        client,
+        query,
+        _source,
+        index_name="registry-refs",
+        page_size=2000,
+        request_timeout_seconds=30,
+        sort_fields=["collection_lidvid", "batch_id"],
+    )
 
     return docs

--- a/src/pds/registrysweepers/ancestry/runtimeconstants.py
+++ b/src/pds/registrysweepers/ancestry/runtimeconstants.py
@@ -11,11 +11,8 @@ class AncestryRuntimeConstants(ABC):
         os.environ.get("ANCESTRY_NONAGGREGATE_QUERY_PAGE_SIZE", 2000)
     )
 
-    # how many nonaggregate history records should be processed before dumping to disk?
-    # Decrease to reduce peak memory demand - increases runtime
-    nonaggregate_records_disk_dump_threshold: int = int(
-        os.environ.get("ANCESTRY_NONAGGREGATE_DISK_DUMP_THRESHOLD", 500000)
-    )
+    # non-aggregate history batches will be dumped to disk periodically as memory usage reaches this threshold
+    disk_dump_memory_percent_threshold: int = int(os.environ.get("ANCESTRY_DISK_DUMP_MEMORY_THRESHOLD", 90))
 
     # Expects a value like "true" or "1"
     disable_chunking: bool = parse_boolean_env_var("ANCESTRY_DISABLE_CHUNKING")

--- a/src/pds/registrysweepers/ancestry/runtimeconstants.py
+++ b/src/pds/registrysweepers/ancestry/runtimeconstants.py
@@ -1,0 +1,19 @@
+import os
+from abc import ABC
+
+
+class AncestryRuntimeConstants(ABC):
+    # how many registry-refs documents (each collection has multiple docs for batches of member non-aggregates)
+    # Decrease to reduce peak memory demand - increases runtime
+    nonaggregate_ancestry_records_query_page_size: int = int(
+        os.environ.get("ANCESTRY_NONAGGREGATE_QUERY_PAGE_SIZE", 2000)
+    )
+
+    # how many nonaggregate history records should be processed before dumping to disk?
+    # Decrease to reduce peak memory demand - increases runtime
+    nonaggregate_records_disk_dump_threshold: int = int(
+        os.environ.get("ANCESTRY_NONAGGREGATE_DISK_DUMP_THRESHOLD", 500000)
+    )
+
+    # Not yet implemented
+    # db_write_timeout_seconds = int(os.environ.get('DB_WRITE_TIMEOUT_SECONDS'), 90)

--- a/src/pds/registrysweepers/ancestry/runtimeconstants.py
+++ b/src/pds/registrysweepers/ancestry/runtimeconstants.py
@@ -12,7 +12,7 @@ class AncestryRuntimeConstants(ABC):
     )
 
     # non-aggregate history batches will be dumped to disk periodically as memory usage reaches this threshold
-    disk_dump_memory_percent_threshold: int = int(os.environ.get("ANCESTRY_DISK_DUMP_MEMORY_THRESHOLD", 90))
+    max_acceptable_memory_usage: int = int(os.environ.get("ANCESTRY_DISK_DUMP_MEMORY_THRESHOLD", 90))
 
     # Expects a value like "true" or "1"
     disable_chunking: bool = parse_boolean_env_var("ANCESTRY_DISABLE_CHUNKING")

--- a/src/pds/registrysweepers/ancestry/runtimeconstants.py
+++ b/src/pds/registrysweepers/ancestry/runtimeconstants.py
@@ -1,6 +1,8 @@
 import os
 from abc import ABC
 
+from pds.registrysweepers.utils.misc import parse_boolean_env_var
+
 
 class AncestryRuntimeConstants(ABC):
     # how many registry-refs documents (each collection has multiple docs for batches of member non-aggregates)
@@ -14,6 +16,9 @@ class AncestryRuntimeConstants(ABC):
     nonaggregate_records_disk_dump_threshold: int = int(
         os.environ.get("ANCESTRY_NONAGGREGATE_DISK_DUMP_THRESHOLD", 500000)
     )
+
+    # Expects a value like "true" or "1"
+    disable_chunking: bool = parse_boolean_env_var("ANCESTRY_DISABLE_CHUNKING")
 
     # Not yet implemented
     # db_write_timeout_seconds = int(os.environ.get('DB_WRITE_TIMEOUT_SECONDS'), 90)

--- a/src/pds/registrysweepers/ancestry/runtimeconstants.py
+++ b/src/pds/registrysweepers/ancestry/runtimeconstants.py
@@ -12,7 +12,7 @@ class AncestryRuntimeConstants(ABC):
     )
 
     # non-aggregate history batches will be dumped to disk periodically as memory usage reaches this threshold
-    max_acceptable_memory_usage: int = int(os.environ.get("ANCESTRY_DISK_DUMP_MEMORY_THRESHOLD", 90))
+    max_acceptable_memory_usage: int = int(os.environ.get("ANCESTRY_DISK_DUMP_MEMORY_THRESHOLD", 80))
 
     # Expects a value like "true" or "1"
     disable_chunking: bool = parse_boolean_env_var("ANCESTRY_DISABLE_CHUNKING")

--- a/src/pds/registrysweepers/ancestry/typedefs.py
+++ b/src/pds/registrysweepers/ancestry/typedefs.py
@@ -1,0 +1,5 @@
+from typing import Dict
+from typing import List
+from typing import Union
+
+SerializableAncestryRecordTypeDef = Dict[str, Union[str, List[str]]]

--- a/src/pds/registrysweepers/ancestry/utils.py
+++ b/src/pds/registrysweepers/ancestry/utils.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 def make_history_serializable(history: Dict[str, Dict[str, Union[str, Set[str], List[str]]]]):
     """Convert history with set attributes into something able to be dumped to JSON"""
-    log.debug(f"Converting history into serializable types...")
+    log.debug("Converting history into serializable types...")
     for lidvid in history.keys():
         history[lidvid]["parent_bundle_lidvids"] = list(history[lidvid]["parent_bundle_lidvids"])
         history[lidvid]["parent_collection_lidvids"] = list(history[lidvid]["parent_collection_lidvids"])
@@ -36,7 +36,7 @@ def dump_history_to_disk(parent_dir: str, history: Dict[str, SerializableAncestr
     return temp_fp
 
 
-def merge_matching_history_chunks(dest_fp: str, src_fps: List[str], max_chunk_size: int = None):
+def merge_matching_history_chunks(dest_fp: str, src_fps: List[str], max_chunk_size: Union[int, None] = None):
     log.info(f"Performing merges into {dest_fp} using max_chunk_size={max_chunk_size}")
     with open(dest_fp, "r") as dest_infile:
         dest_file_content: Dict[str, SerializableAncestryRecordTypeDef] = json.load(dest_infile)

--- a/src/pds/registrysweepers/ancestry/utils.py
+++ b/src/pds/registrysweepers/ancestry/utils.py
@@ -36,7 +36,7 @@ def dump_history_to_disk(parent_dir: str, history: Dict[str, SerializableAncestr
     return temp_fp
 
 
-def merge_matching_history_chunks(dest_fp: str, src_fps: List[str], max_chunk_size: int):
+def merge_matching_history_chunks(dest_fp: str, src_fps: List[str], max_chunk_size: int = None):
     log.info(f"Performing merges into {dest_fp} using max_chunk_size={max_chunk_size}")
     with open(dest_fp, "r") as dest_infile:
         dest_file_content: Dict[str, SerializableAncestryRecordTypeDef] = json.load(dest_infile)
@@ -95,13 +95,16 @@ def merge_matching_history_chunks(dest_fp: str, src_fps: List[str], max_chunk_si
     log.debug("    complete!")
 
 
-def split_chunk_if_oversized(max_chunk_size: int, parent_dir: str, content: Dict) -> Union[str, None]:
+def split_chunk_if_oversized(max_chunk_size: Union[int, None], parent_dir: str, content: Dict) -> Union[str, None]:
     """
     To keep memory usage near expected bounds, it's necessary to avoid accumulation into a merge destination chunk such
     that its size balloons beyond the size of a pre-merge chunk.  This is achieved by splitting the chunk approximately
     in half, if its size exceeds the given threshold, and returning the newly-created chunk's filepath for addition to
     the processing queue.
     """
+    if max_chunk_size is None:
+        return None
+
     if not sys.getsizeof(content) > max_chunk_size:
         return None
 

--- a/src/pds/registrysweepers/ancestry/utils.py
+++ b/src/pds/registrysweepers/ancestry/utils.py
@@ -53,7 +53,7 @@ def make_history_serializable(history: Dict[PdsLidVid, AncestryRecord]) -> Dict[
 
 
 def dump_history_to_disk(parent_dir: str, history: Dict[str, SerializableAncestryRecordTypeDef]):
-    temp_fp = os.path.join(parent_dir, datetime.now().isoformat())
+    temp_fp = os.path.join(parent_dir, datetime.now().isoformat().replace(":", "-"))
     log.info(f"Dumping history of {len(history)} products to {temp_fp} for later merging")
     with open(temp_fp, "w+") as outfile:
         json.dump(history, outfile)

--- a/src/pds/registrysweepers/ancestry/utils.py
+++ b/src/pds/registrysweepers/ancestry/utils.py
@@ -28,7 +28,7 @@ def make_history_serializable(history: Dict[str, Dict[str, Union[str, Set[str], 
 def dump_history_to_disk(parent_dir: str, history: Dict[str, SerializableAncestryRecordTypeDef]) -> str:
     """Dump set of history records to disk and return the filepath"""
     temp_fp = os.path.join(parent_dir, datetime.now().isoformat().replace(":", "-"))
-    log.info(f"Dumping history to {temp_fp} for later merging...")
+    log.debug(f"Dumping history to {temp_fp} for later merging...")
     with open(temp_fp, "w+") as outfile:
         json.dump(history, outfile)
     log.debug("    complete!")
@@ -37,7 +37,7 @@ def dump_history_to_disk(parent_dir: str, history: Dict[str, SerializableAncestr
 
 
 def merge_matching_history_chunks(dest_fp: str, src_fps: List[str], max_chunk_size: Union[int, None] = None):
-    log.info(f"Performing merges into {dest_fp} using max_chunk_size={max_chunk_size}")
+    log.debug(f"Performing merges into {dest_fp} using max_chunk_size={max_chunk_size}")
     with open(dest_fp, "r") as dest_infile:
         dest_file_content: Dict[str, SerializableAncestryRecordTypeDef] = json.load(dest_infile)
 
@@ -114,7 +114,7 @@ def split_chunk_if_oversized(max_chunk_size: Union[int, None], parent_dir: str, 
         split_content[k] = content.pop(k)
 
     split_filepath = dump_history_to_disk(parent_dir, split_content)
-    log.info(f"split off excess chunk content to new file: {split_filepath}")
+    log.debug(f"split off excess chunk content to new file: {split_filepath}")
     return split_filepath
 
 

--- a/src/pds/registrysweepers/ancestry/utils.py
+++ b/src/pds/registrysweepers/ancestry/utils.py
@@ -5,26 +5,22 @@ from datetime import datetime
 from typing import Dict
 from typing import Iterable
 from typing import List
+from typing import Set
 from typing import Union
 
 from pds.registrysweepers.ancestry import AncestryRecord
 from pds.registrysweepers.ancestry.typedefs import SerializableAncestryRecordTypeDef
-from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
 
 log = logging.getLogger(__name__)
 
 
-def make_history_serializable(history: Dict[PdsLidVid, AncestryRecord]) -> Dict[str, SerializableAncestryRecordTypeDef]:
-    """Destructively convert history into something able to be dumped to JSON"""
+def make_history_serializable(history: Dict[str, Dict[str, Union[str, Set[str], List[str]]]]):
+    """Convert history with set attributes into something able to be dumped to JSON"""
     log.debug(f"Converting history into serializable types...")
-    serializable_history: Dict[str, SerializableAncestryRecordTypeDef] = {}
-    for old_k in list(history.keys()):
-        old_v = history.pop(old_k)
-        new_k = str(old_k)
-        new_v = old_v.to_dict()
-        serializable_history[new_k] = new_v
+    for lidvid in history.keys():
+        history[lidvid]["parent_bundle_lidvids"] = list(history[lidvid]["parent_bundle_lidvids"])
+        history[lidvid]["parent_collection_lidvids"] = list(history[lidvid]["parent_collection_lidvids"])
     log.debug("    complete!")
-    return serializable_history
 
 
 def dump_history_to_disk(parent_dir: str, history: Dict[str, SerializableAncestryRecordTypeDef]):

--- a/src/pds/registrysweepers/ancestry/utils.py
+++ b/src/pds/registrysweepers/ancestry/utils.py
@@ -1,6 +1,8 @@
+import gc
 import json
 import logging
 import os
+import sys
 from datetime import datetime
 from typing import Dict
 from typing import Iterable
@@ -23,29 +25,40 @@ def make_history_serializable(history: Dict[str, Dict[str, Union[str, Set[str], 
     log.debug("    complete!")
 
 
-def dump_history_to_disk(parent_dir: str, history: Dict[str, SerializableAncestryRecordTypeDef]):
+def dump_history_to_disk(parent_dir: str, history: Dict[str, SerializableAncestryRecordTypeDef]) -> str:
+    """Dump set of history records to disk and return the filepath"""
     temp_fp = os.path.join(parent_dir, datetime.now().isoformat().replace(":", "-"))
     log.info(f"Dumping history to {temp_fp} for later merging...")
     with open(temp_fp, "w+") as outfile:
         json.dump(history, outfile)
     log.debug("    complete!")
 
+    return temp_fp
 
-def merge_matching_history_chunks(dest_fp: str, src_fps: Iterable[str]):
-    log.info(f"Performing merges into {dest_fp}")
+
+def merge_matching_history_chunks(dest_fp: str, src_fps: List[str], max_chunk_size: int):
+    log.info(f"Performing merges into {dest_fp} using max_chunk_size={max_chunk_size}")
     with open(dest_fp, "r") as dest_infile:
         dest_file_content: Dict[str, SerializableAncestryRecordTypeDef] = json.load(dest_infile)
+
+    dest_file_updated = False
 
     for src_fn in src_fps:
         log.debug(f"merging from {src_fn}...")
         with open(src_fn, "r") as src_infile:
             src_file_content: Dict[str, SerializableAncestryRecordTypeDef] = json.load(src_infile)
 
+        src_file_updated = False
+
         # For every lidvid with history in the "active" file, absorb all relevant history from this inactive file
         for lidvid_str, dest_history_entry in dest_file_content.items():
             try:
                 src_history_to_merge = src_file_content[lidvid_str]
                 src_file_content.pop(lidvid_str)
+
+                # Flag files as updated - will trigger re-write to disk
+                dest_file_updated = True
+                src_file_updated = True
 
                 dest_history_entry = dest_file_content[lidvid_str]
                 for k in ["parent_bundle_lidvids", "parent_collection_lidvids"]:
@@ -55,15 +68,51 @@ def merge_matching_history_chunks(dest_fp: str, src_fps: Iterable[str]):
                 # If the src history doesn't contain history for this lidvid, there's nothing to do
                 pass
 
-        # Overwrite the content of the source file with any remaining history not absorbed
-        with open(src_fn, "w+") as src_outfile:
-            json.dump(src_file_content, src_outfile)
+        if src_file_updated:
+            # Overwrite the content of the source file with any remaining history not absorbed
+            with open(src_fn, "w+") as src_outfile:
+                json.dump(src_file_content, src_outfile)
 
-    # Overwrite the content of the destination file with any remaining history not absorbed
-    with open(dest_fp, "w+") as src_outfile:
-        json.dump(dest_file_content, src_outfile)
+        # this prevents a memory spike when reading in the next chunk of src_file_content
+        del src_file_content
+        gc.collect()
+
+        dest_parent_dir = os.path.split(dest_fp)[0]
+        split_filepath = split_chunk_if_oversized(max_chunk_size, dest_parent_dir, dest_file_content)
+        if split_filepath is not None:
+            # the path of the newly-created file with the split-off data is appended and will be processed next
+            # intuitively it seems like this is most-likely to create the fewest additional split-off files as it should
+            # avoid a bunch of unnecessary split-off files with overlapping content, but this is just a hunch which
+            # won't hurt anything to follow
+            src_fps.append(split_filepath)
+            dest_file_updated = True
+
+    if dest_file_updated:
+        # Overwrite the content of the destination file with updated history including absorbed elements
+        with open(dest_fp, "w+") as src_outfile:
+            json.dump(dest_file_content, src_outfile)
 
     log.debug("    complete!")
+
+
+def split_chunk_if_oversized(max_chunk_size: int, parent_dir: str, content: Dict) -> Union[str, None]:
+    """
+    To keep memory usage near expected bounds, it's necessary to avoid accumulation into a merge destination chunk such
+    that its size balloons beyond the size of a pre-merge chunk.  This is achieved by splitting the chunk approximately
+    in half, if its size exceeds the given threshold, and returning the newly-created chunk's filepath for addition to
+    the processing queue.
+    """
+    if not sys.getsizeof(content) > max_chunk_size:
+        return None
+
+    split_content = {}
+    collection_keys = list(content.keys())
+    for k in collection_keys[::2]:  # pick every second key
+        split_content[k] = content.pop(k)
+
+    split_filepath = dump_history_to_disk(parent_dir, split_content)
+    log.info(f"split off excess chunk content to new file: {split_filepath}")
+    return split_filepath
 
 
 def load_partial_history_to_records(fn: str) -> Iterable[AncestryRecord]:

--- a/src/pds/registrysweepers/ancestry/utils.py
+++ b/src/pds/registrysweepers/ancestry/utils.py
@@ -1,0 +1,100 @@
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Union
+
+from pds.registrysweepers.ancestry import AncestryRecord
+from pds.registrysweepers.ancestry.typedefs import SerializableAncestryRecordTypeDef
+from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
+
+log = logging.getLogger(__name__)
+
+
+def produce_nonaggregate_iterable(
+    collection_refs_query_docs: Iterable[Dict],
+) -> Iterable[Dict[str, PdsLidVid]]:
+    """
+    Given a set of collection-level docs returned from the registry-refs index, emit a doc for each non-aggregate
+     ref contained within, attaching the collection lidvid.
+    This exists so that it is possible to page over non-aggregate-level documents using a specified page size.
+    """
+
+    for doc in collection_refs_query_docs:
+        try:
+            collection_lidvid = PdsLidVid.from_string(doc["_source"]["collection_lidvid"])
+            for nonaggregate_lidvid_str in doc["_source"]["product_lidvid"]:
+                nonaggregate_lidvid = PdsLidVid.from_string(nonaggregate_lidvid_str)
+                yield {"collection_lidvid": collection_lidvid, "nonaggregate_lidvid": nonaggregate_lidvid}
+        except (ValueError, KeyError) as err:
+            log.warning(
+                'Failed to parse collection and/or product LIDVIDs from document in index "%s" with id "%s" due to %s: %s',
+                doc.get("_index"),
+                doc.get("_id"),
+                type(err).__name__,
+                err,
+            )
+            continue
+
+
+def make_history_serializable(history: Dict[PdsLidVid, AncestryRecord]) -> Dict[str, SerializableAncestryRecordTypeDef]:
+    """Destructively convert history into something able to be dumped to JSON"""
+    serializable_history: Dict[str, SerializableAncestryRecordTypeDef] = {}
+    for old_k in list(history.keys()):
+        old_v = history.pop(old_k)
+        new_k = str(old_k)
+        new_v = old_v.to_dict()
+        serializable_history[new_k] = new_v
+
+    return serializable_history
+
+
+def dump_history_to_disk(parent_dir: str, history: Dict[str, SerializableAncestryRecordTypeDef]):
+    temp_fp = os.path.join(parent_dir, datetime.now().isoformat())
+    log.info(f"Dumping history of {len(history)} products to {temp_fp} for later merging")
+    with open(temp_fp, "w+") as outfile:
+        json.dump(history, outfile)
+
+
+def merge_matching_history_chunks(dest_fp: str, src_fps: Iterable[str]):
+    log.info(f"Performing merges into {dest_fp}")
+    with open(dest_fp, "r") as dest_infile:
+        dest_file_content: Dict[str, SerializableAncestryRecordTypeDef] = json.load(dest_infile)
+
+    for src_fn in src_fps:
+        log.debug(f"merging from {src_fn}...")
+        with open(src_fn, "r") as src_infile:
+            src_file_content: Dict[str, SerializableAncestryRecordTypeDef] = json.load(src_infile)
+
+        # For every lidvid with history in the "active" file, absorb all relevant history from this inactive file
+        for lidvid_str, dest_history_entry in dest_file_content.items():
+            try:
+                src_history_to_merge = src_file_content[lidvid_str]
+                src_file_content.pop(lidvid_str)
+
+                dest_history_entry = dest_file_content[lidvid_str]
+                for k in ["parent_bundle_lidvids", "parent_collection_lidvids"]:
+                    dest_history_entry[k].extend(src_history_to_merge[k])  # type: ignore
+
+            except KeyError:
+                # If the src history doesn't contain history for this lidvid, there's nothing to do
+                pass
+
+        # Overwrite the content of the source file with any remaining history not absorbed
+        with open(src_fn, "w+") as src_outfile:
+            json.dump(src_file_content, src_outfile)
+
+    # Overwrite the content of the destination file with any remaining history not absorbed
+    with open(dest_fp, "w+") as src_outfile:
+        json.dump(dest_file_content, src_outfile)
+
+
+def load_partial_history_to_records(fn: str) -> Iterable[AncestryRecord]:
+    with open(fn, "r") as infile:
+        content: Dict[str, SerializableAncestryRecordTypeDef] = json.load(infile)
+
+    for history_dict in content.values():
+        yield AncestryRecord.from_dict(history_dict)

--- a/src/pds/registrysweepers/provenance/__init__.py
+++ b/src/pds/registrysweepers/provenance/__init__.py
@@ -109,9 +109,9 @@ def get_successors_by_lidvid(extant_lidvids: Iterable[str]) -> Mapping[str, str]
 
     log.info(f"Successors will be updated for {len(successors_by_lidvid)} LIDVIDs!")
 
-    if log.isEnabledFor(logging.DEBUG):
-        for lidvid in successors_by_lidvid.keys():
-            log.debug(f"{lidvid}")
+    # if log.isEnabledFor(logging.DEBUG):
+    #     for lidvid in successors_by_lidvid.keys():
+    #         log.debug(f"{lidvid}")
 
     return successors_by_lidvid
 

--- a/src/pds/registrysweepers/provenance/__init__.py
+++ b/src/pds/registrysweepers/provenance/__init__.py
@@ -109,10 +109,6 @@ def get_successors_by_lidvid(extant_lidvids: Iterable[str]) -> Mapping[str, str]
 
     log.info(f"Successors will be updated for {len(successors_by_lidvid)} LIDVIDs!")
 
-    # if log.isEnabledFor(logging.DEBUG):
-    #     for lidvid in successors_by_lidvid.keys():
-    #         log.debug(f"{lidvid}")
-
     return successors_by_lidvid
 
 

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -63,7 +63,7 @@ def generate_updates(
         id = document["_id"]
         src = document["_source"]
         repairs = {repairkit_version_metadata_key: int(repairkit_version)}
-        log.debug(f"applying repairkit sweeper to document: {id}")
+        # log.debug(f"applying repairkit sweeper to document: {id}")
         for fieldname, data in src.items():
             for regex, funcs in REPAIR_TOOLS.items():
                 if regex(fieldname):

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -63,7 +63,6 @@ def generate_updates(
         id = document["_id"]
         src = document["_source"]
         repairs = {repairkit_version_metadata_key: int(repairkit_version)}
-        # log.debug(f"applying repairkit sweeper to document: {id}")
         for fieldname, data in src.items():
             for regex, funcs in REPAIR_TOOLS.items():
                 if regex(fieldname):

--- a/src/pds/registrysweepers/repairkit/allarrays.py
+++ b/src/pds/registrysweepers/repairkit/allarrays.py
@@ -22,7 +22,6 @@ def repair(document: Dict, fieldname: str) -> Dict:
     if fieldname in EXCLUDED_PROPERTIES or fieldname.startswith("ops:Provenance"):
         return {}
 
-    # log.debug(f"checking {fieldname}")
     if isinstance(document[fieldname], str):
         log.debug(f"found string in doc {document.get('_id')} for field {fieldname} where it should be an array")
         return {fieldname: [document[fieldname]]}

--- a/src/pds/registrysweepers/repairkit/allarrays.py
+++ b/src/pds/registrysweepers/repairkit/allarrays.py
@@ -22,8 +22,8 @@ def repair(document: Dict, fieldname: str) -> Dict:
     if fieldname in EXCLUDED_PROPERTIES or fieldname.startswith("ops:Provenance"):
         return {}
 
-    log.debug(f"checking {fieldname}")
+    # log.debug(f"checking {fieldname}")
     if isinstance(document[fieldname], str):
-        log.debug(f"found string for {fieldname} where it should be an array")
+        log.debug(f"found string in doc {document.get('_id')} for field {fieldname} where it should be an array")
         return {fieldname: [document[fieldname]]}
     return {}

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -79,9 +79,6 @@ def query_registry_db(
         total_hits = results["hits"]["total"]["value"]
         if served_hits == 0:
             log.info(f"Query {query_id} returns {total_hits} total hits")
-        log.debug(
-            f"   paging query {query_id} ({served_hits} to {min(served_hits + page_size, total_hits)} of {total_hits})"
-        )
 
         response_hits = results["hits"]["hits"]
         for hit in response_hits:
@@ -184,9 +181,6 @@ def query_registry_db_with_search_after(
         expected_pages = math.ceil(total_hits / page_size)
         if served_hits == 0:
             log.info(f"Query {query_id} returns {total_hits} total hits")
-        log.debug(
-            f"   paging query {query_id} ({served_hits} to {min(served_hits + page_size, total_hits)} of {total_hits})"
-        )
 
         response_hits = results["hits"]["hits"]
         for hit in response_hits:

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -295,11 +295,11 @@ def update_as_statements(update: Update) -> Iterable[str]:
     return updates_strs
 
 
-@retry(tries=6, delay=2, backoff=2, logger=log)
+@retry(tries=6, delay=15, backoff=2, logger=log)
 def _write_bulk_updates_chunk(client: OpenSearch, index_name: str, bulk_updates: Iterable[str]):
     bulk_data = "\n".join(bulk_updates) + "\n"
 
-    request_timeout = 60
+    request_timeout = 90
     response_content = client.bulk(index=index_name, body=bulk_data, request_timeout=request_timeout)
 
     if response_content.get("errors"):

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -37,12 +37,12 @@ def query_registry_db(
 
     scroll_keepalive = f"{scroll_keepalive_minutes}m"
     query_id = get_random_hex_id()  # This is just used to differentiate queries during logging
-    log.info(f"Initiating query (id {query_id}) of index {index_name}: {json.dumps(query)}")
+    log.debug(f"Initiating query (id {query_id}) of index {index_name}: {json.dumps(query)}")
 
     served_hits = 0
 
     last_info_log_at_percentage = 0
-    log.info(f"Query {query_id} progress: 0%")
+    log.debug(f"Query {query_id} progress: 0%")
 
     more_data_exists = True
     scroll_id = None
@@ -78,7 +78,7 @@ def query_registry_db(
 
         total_hits = results["hits"]["total"]["value"]
         if served_hits == 0:
-            log.info(f"Query {query_id} returns {total_hits} total hits")
+            log.debug(f"Query {query_id} returns {total_hits} total hits")
 
         response_hits = results["hits"]["hits"]
         for hit in response_hits:
@@ -87,7 +87,7 @@ def query_registry_db(
             percentage_of_hits_served = int(served_hits / total_hits * 100)
             if last_info_log_at_percentage is None or percentage_of_hits_served >= (last_info_log_at_percentage + 5):
                 last_info_log_at_percentage = percentage_of_hits_served
-                log.info(f"Query {query_id} progress: {percentage_of_hits_served}%")
+                log.debug(f"Query {query_id} progress: {percentage_of_hits_served}%")
 
             yield hit
 
@@ -113,7 +113,7 @@ def query_registry_db(
         logger=log,
     )
 
-    log.info(f"Query {query_id} complete!")
+    log.debug(f"Query {query_id} complete!")
 
 
 def query_registry_db_with_search_after(
@@ -138,12 +138,12 @@ def query_registry_db_with_search_after(
     sort_fields = sort_fields or ["lidvid"]
 
     query_id = get_random_hex_id()  # This is just used to differentiate queries during logging
-    log.info(f"Initiating query with id {query_id}: {json.dumps(query)}")
+    log.debug(f"Initiating query with id {query_id}: {json.dumps(query)}")
 
     served_hits = 0
 
     last_info_log_at_percentage = 0
-    log.info(f"Query {query_id} progress: 0%")
+    log.debug(f"Query {query_id} progress: 0%")
 
     more_data_exists = True
     search_after_values: Union[List, None] = None
@@ -152,7 +152,7 @@ def query_registry_db_with_search_after(
     while more_data_exists:
         if search_after_values is not None:
             query["search_after"] = search_after_values
-            log.info(
+            log.debug(
                 f"Query {query_id} paging {page_size} hits (page {current_page} of {expected_pages}) with sort fields {sort_fields} and search-after values {search_after_values}"
             )
 
@@ -180,7 +180,7 @@ def query_registry_db_with_search_after(
         current_page += 1
         expected_pages = math.ceil(total_hits / page_size)
         if served_hits == 0:
-            log.info(f"Query {query_id} returns {total_hits} total hits")
+            log.debug(f"Query {query_id} returns {total_hits} total hits")
 
         response_hits = results["hits"]["hits"]
         for hit in response_hits:
@@ -189,7 +189,7 @@ def query_registry_db_with_search_after(
             percentage_of_hits_served = int(served_hits / total_hits * 100)
             if last_info_log_at_percentage is None or percentage_of_hits_served >= (last_info_log_at_percentage + 5):
                 last_info_log_at_percentage = percentage_of_hits_served
-                log.info(f"Query {query_id} progress: {percentage_of_hits_served}%")
+                log.debug(f"Query {query_id} progress: {percentage_of_hits_served}%")
 
             yield hit
 
@@ -209,7 +209,7 @@ def query_registry_db_with_search_after(
 
         more_data_exists = served_hits < results["hits"]["total"]["value"]
 
-    log.info(f"Query {query_id} complete!")
+    log.debug(f"Query {query_id} complete!")
 
 
 def query_registry_db_or_mock(
@@ -260,7 +260,7 @@ def write_updated_docs(
         )
 
         if flush_threshold_reached:
-            log.info(
+            log.debug(
                 f"Bulk update buffer has reached {threshold_log_str} threshold - writing {buffered_updates_count} document updates to db..."
             )
             _write_bulk_updates_chunk(client, index_name, bulk_updates_buffer)
@@ -276,7 +276,7 @@ def write_updated_docs(
         updated_doc_count += 1
 
     if len(bulk_updates_buffer) > 0:
-        log.info(f"Writing documents updates for {buffered_updates_count} remaining products to db...")
+        log.debug(f"Writing documents updates for {buffered_updates_count} remaining products to db...")
         _write_bulk_updates_chunk(client, index_name, bulk_updates_buffer)
 
     log.info(f"Updated documents for {updated_doc_count} total products!")
@@ -332,7 +332,7 @@ def _write_bulk_updates_chunk(client: OpenSearch, index_name: str, bulk_updates:
                         f"Attempt to update the following documents failed unexpectedly due to {error_type} ({error_reason}): {ids_str}"
                     )
     else:
-        log.info("Successfully wrote bulk update chunk")
+        log.debug("Successfully wrote bulk update chunk")
 
 
 def aggregate_update_error_types(items: Iterable[Dict]) -> Mapping[str, Dict[str, List[str]]]:

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -122,7 +122,7 @@ def query_registry_db_with_search_after(
     _source: Dict,
     index_name: str = "registry",
     page_size: int = 10000,
-    sort_fields: List[str] = None,
+    sort_fields: Union[List[str], None] = None,
     request_timeout_seconds: int = 20,
 ) -> Iterable[Dict]:
     """
@@ -225,7 +225,7 @@ def query_registry_db_or_mock(
             page_size: int = 10000,
             scroll_validity_duration_minutes: int = 10,
             request_timeout_seconds: int = 20,
-            sort_fields: List[str] = [],
+            sort_fields: Union[List[str], None] = None,
         ) -> Iterable[Dict]:
             return mock_f(mock_query_id)  # type: ignore  # see None-check above
 

--- a/src/pds/registrysweepers/utils/misc.py
+++ b/src/pds/registrysweepers/utils/misc.py
@@ -2,7 +2,9 @@ import random
 from datetime import datetime
 from typing import Any
 from typing import Callable
+from typing import Iterable
 from typing import List
+from typing import TypeVar
 
 
 def coerce_list_type(db_value: Any) -> List[Any]:
@@ -51,3 +53,23 @@ def auto_raise_for_status(f: Callable) -> Callable:
 
 def get_sweeper_version_metadata_key(sweeper_name: str) -> str:
     return f"ops:Provenance/ops:registry_sweepers_{sweeper_name}_version"
+
+
+T = TypeVar("T")
+
+
+def iterate_pages_of(page_size: int, iterable: Iterable[T]) -> Iterable[List[T]]:
+    """Provides a simple interface for lazily iterating over pages of an arbitrary iterable"""
+    if page_size < 1:
+        raise ValueError(f"Cannot iterate over pages of size <1 (got {page_size})")
+
+    page: List[T] = []
+    for el in iterable:
+        if len(page) == page_size:
+            yield page
+            page = []
+
+        page.append(el)
+
+    if len(page) > 0:
+        yield page

--- a/src/pds/registrysweepers/utils/misc.py
+++ b/src/pds/registrysweepers/utils/misc.py
@@ -1,3 +1,4 @@
+import os
 import random
 from datetime import datetime
 from typing import Any
@@ -73,3 +74,18 @@ def iterate_pages_of(page_size: int, iterable: Iterable[T]) -> Iterable[List[T]]
 
     if len(page) > 0:
         yield page
+
+
+def parse_boolean_env_var(key: str) -> bool:
+    raw_value = os.environ.get(key)
+
+    valid_truthy_values = ["true", "True", "TRUE", "1"]
+    valid_falsy_values = ["false", "False", "FALSE", "0", ""]
+    if raw_value in valid_falsy_values or raw_value is None:
+        return False
+    elif raw_value in valid_truthy_values:
+        return True
+    else:
+        raise ValueError(
+            f'Could not parse valid boolean from env var "{key}" - expected {valid_truthy_values} for True or {valid_falsy_values} for False'
+        )

--- a/tests/pds/registrysweepers/ancestry/test_ancestryrecord.py
+++ b/tests/pds/registrysweepers/ancestry/test_ancestryrecord.py
@@ -1,0 +1,78 @@
+import unittest
+
+from pds.registrysweepers.ancestry import AncestryRecord
+from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
+
+
+class AncestryRecordTestCase(unittest.TestCase):
+    def test_serialization(self):
+        lidvid_str = "a:b:c:d:e:f::1.0"
+        collection_lidvid_strs = ["a:b:c:d:e::1.0", "a:b:c:d:e::2.0"]
+        bundle_lidvid_strs = ["a:b:c:d::1.0", "a:b:c:d::2.0"]
+
+        record = AncestryRecord(
+            lidvid=PdsLidVid.from_string(lidvid_str),
+            parent_collection_lidvids=set(PdsLidVid.from_string(id) for id in collection_lidvid_strs),
+            parent_bundle_lidvids=set(PdsLidVid.from_string(id) for id in bundle_lidvid_strs),
+        )
+
+        expected_dict_repr = {
+            "lidvid": "a:b:c:d:e:f::1.0",
+            "parent_collection_lidvids": ["a:b:c:d:e::1.0", "a:b:c:d:e::2.0"],
+            "parent_bundle_lidvids": ["a:b:c:d::1.0", "a:b:c:d::2.0"],
+        }
+
+        self.assertEqual(record, AncestryRecord.from_dict(expected_dict_repr))
+        self.assertEqual(expected_dict_repr, record.to_dict())
+
+    def test_update_with_basic_functionality(self):
+        lidvid_str = "a:b:c:d:e:f::1.0"
+        mismatched_lidvid_str = "a:b:c:d:e:f::2.0"
+        collection_lidvid_strs = ["a:b:c:d:e::1.0", "a:b:c:d:e::2.0"]
+        bundle_lidvid_strs = ["a:b:c:d::1.0", "a:b:c:d::2.0"]
+
+        dest = AncestryRecord(
+            lidvid=PdsLidVid.from_string(lidvid_str),
+            parent_collection_lidvids={
+                PdsLidVid.from_string(collection_lidvid_strs[0]),
+            },
+            parent_bundle_lidvids={
+                PdsLidVid.from_string(bundle_lidvid_strs[0]),
+            },
+        )
+
+        src = AncestryRecord(
+            lidvid=PdsLidVid.from_string(lidvid_str),
+            parent_collection_lidvids={
+                PdsLidVid.from_string(collection_lidvid_strs[1]),
+            },
+            parent_bundle_lidvids={
+                PdsLidVid.from_string(bundle_lidvid_strs[1]),
+            },
+        )
+
+        expected = AncestryRecord(
+            lidvid=PdsLidVid.from_string(lidvid_str),
+            parent_collection_lidvids={PdsLidVid.from_string(id) for id in collection_lidvid_strs},
+            parent_bundle_lidvids={PdsLidVid.from_string(id) for id in bundle_lidvid_strs},
+        )
+
+        dest.update_with(src)
+        self.assertEqual(expected, dest, "update_with() works")
+
+        bad_src = AncestryRecord(
+            lidvid=PdsLidVid.from_string(mismatched_lidvid_str),
+            parent_collection_lidvids={
+                PdsLidVid.from_string(collection_lidvid_strs[1]),
+            },
+            parent_bundle_lidvids={
+                PdsLidVid.from_string(bundle_lidvid_strs[1]),
+            },
+        )
+
+        # test update_with() raises ValueError on mismatched lidvids
+        self.assertRaises(ValueError, lambda: dest.update_with(bad_src))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pds/registrysweepers/ancestry/test_utils.py
+++ b/tests/pds/registrysweepers/ancestry/test_utils.py
@@ -1,0 +1,81 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from pds.registrysweepers.ancestry import AncestryRecord
+from pds.registrysweepers.ancestry.utils import make_history_serializable
+from pds.registrysweepers.ancestry.utils import merge_matching_history_chunks
+from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
+
+
+class TestMakeHistorySerializableTestCase(unittest.TestCase):
+    def test_basic_behaviour(self):
+        input = {
+            r.lidvid: r
+            for r in [
+                AncestryRecord(
+                    lidvid=PdsLidVid.from_string(f"a:b:c:d:e:{x}::1.0"),
+                    parent_collection_lidvids={PdsLidVid.from_string("a:b:c:d:e::1.0")},
+                    parent_bundle_lidvids={PdsLidVid.from_string("a:b:c:d::1.0")},
+                )
+                for x in ["A", "B", "C"]
+            ]
+        }
+
+        expected = {
+            str(r["lidvid"]): r
+            for r in [
+                {
+                    "lidvid": f"a:b:c:d:e:{x}::1.0",
+                    "parent_collection_lidvids": ["a:b:c:d:e::1.0"],
+                    "parent_bundle_lidvids": ["a:b:c:d::1.0"],
+                }
+                for x in ["A", "B", "C"]
+            ]
+        }
+
+        serializable_history = make_history_serializable(input)
+
+        self.assertDictEqual(expected, serializable_history)
+        self.assertEqual(0, len(input), "input was consumed")
+
+
+class TestMergeMatchingHistoryChunksTestCase(unittest.TestCase):
+    def setUp(self):
+        setup_fp = os.path.abspath(
+            "./tests/pds/registrysweepers/ancestry/test_utils_merge_matching_history_chunks.json"
+        )
+        with open(setup_fp) as setup_infile:
+            setup_content = json.load(setup_infile)
+
+        self.temp_dir = tempfile.mkdtemp()
+        for fn, file_content in setup_content["inputs"].items():
+            with open(os.path.join(self.temp_dir, fn), "w+") as setup_outfile:
+                json.dump(file_content, setup_outfile)
+
+        self.dest_fp = os.path.join(self.temp_dir, "dest.json")
+        self.src_fps = [os.path.join(self.temp_dir, f"src{i}.json") for i in range(1, 3)]
+
+        self.expected_outputs = setup_content["outputs"]
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+        self.temp_dir = None
+
+    def test_merges_correctly(self):
+        merge_matching_history_chunks(self.dest_fp, self.src_fps)
+        for fn, content in self.expected_outputs.items():
+            fp = os.path.join(self.temp_dir, fn)
+            with open(fp, "r") as result_infile:
+                content = json.load(result_infile)
+                self.assertDictEqual(self.expected_outputs[fn], content)
+                print(fp)
+                print(content)
+                print(self.expected_outputs[fn])
+                print("\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pds/registrysweepers/ancestry/test_utils.py
+++ b/tests/pds/registrysweepers/ancestry/test_utils.py
@@ -13,13 +13,13 @@ from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
 class TestMakeHistorySerializableTestCase(unittest.TestCase):
     def test_basic_behaviour(self):
         input = {
-            r.lidvid: r
+            r["lidvid"]: r
             for r in [
-                AncestryRecord(
-                    lidvid=PdsLidVid.from_string(f"a:b:c:d:e:{x}::1.0"),
-                    parent_collection_lidvids={PdsLidVid.from_string("a:b:c:d:e::1.0")},
-                    parent_bundle_lidvids={PdsLidVid.from_string("a:b:c:d::1.0")},
-                )
+                {
+                    "lidvid": f"a:b:c:d:e:{x}::1.0",
+                    "parent_collection_lidvids": {"a:b:c:d:e::1.0"},
+                    "parent_bundle_lidvids": {"a:b:c:d::1.0"},
+                }
                 for x in ["A", "B", "C"]
             ]
         }
@@ -36,10 +36,9 @@ class TestMakeHistorySerializableTestCase(unittest.TestCase):
             ]
         }
 
-        serializable_history = make_history_serializable(input)
+        make_history_serializable(input)
 
-        self.assertDictEqual(expected, serializable_history)
-        self.assertEqual(0, len(input), "input was consumed")
+        self.assertDictEqual(expected, input)
 
 
 class TestMergeMatchingHistoryChunksTestCase(unittest.TestCase):

--- a/tests/pds/registrysweepers/ancestry/test_utils_merge_matching_history_chunks.json
+++ b/tests/pds/registrysweepers/ancestry/test_utils_merge_matching_history_chunks.json
@@ -1,0 +1,112 @@
+{
+  "inputs": {
+    "dest.json": {
+      "a:b:c:d:e:A::1.0": {
+        "lidvid": "a:b:c:d:e:A::1.0",
+        "parent_collection_lidvids": [
+          "a:b:c:d:e::1.0"
+        ],
+        "parent_bundle_lidvids": [
+          "a:b:c:d::1.0"
+        ]
+      },
+      "a:b:c:d:e:B::1.0": {
+        "lidvid": "a:b:c:d:e:B::1.0",
+        "parent_collection_lidvids": [
+          "a:b:c:d:e::1.0"
+        ],
+        "parent_bundle_lidvids": [
+          "a:b:c:d::1.0"
+        ]
+      }
+    },
+    "src1.json": {
+      "a:b:c:d:e:A::1.0": {
+        "lidvid": "a:b:c:d:e:A::1.0",
+        "parent_collection_lidvids": [
+          "a:b:c:d:e::2.0"
+        ],
+        "parent_bundle_lidvids": [
+          "a:b:c:d::2.0"
+        ]
+      },
+      "a:b:c:d:e:a::1.0": {
+        "lidvid": "a:b:c:d:e:a::1.0",
+        "parent_collection_lidvids": [
+          "a:b:c:d:e::1.1"
+        ],
+        "parent_bundle_lidvids": [
+          "a:b:c:d::1.1"
+        ]
+      }
+    },
+    "src2.json": {
+      "a:b:c:d:e:A::1.0": {
+        "lidvid": "a:b:c:d:e:A::1.0",
+        "parent_collection_lidvids": [
+          "a:b:c:d:e::3.0"
+        ],
+        "parent_bundle_lidvids": [
+          "a:b:c:d::3.0"
+        ]
+      },
+      "a:b:c:d:e:b::1.0": {
+        "lidvid": "a:b:c:d:e:b::1.0",
+        "parent_collection_lidvids": [
+          "a:b:c:d:e::1.2"
+        ],
+        "parent_bundle_lidvids": [
+          "a:b:c:d::1.2"
+        ]
+      }
+    }
+  },
+  "outputs": {
+    "dest.json": {
+      "a:b:c:d:e:A::1.0": {
+        "lidvid": "a:b:c:d:e:A::1.0",
+        "parent_collection_lidvids": [
+          "a:b:c:d:e::1.0",
+          "a:b:c:d:e::2.0",
+          "a:b:c:d:e::3.0"
+        ],
+        "parent_bundle_lidvids": [
+          "a:b:c:d::1.0",
+          "a:b:c:d::2.0",
+          "a:b:c:d::3.0"
+        ]
+      },
+      "a:b:c:d:e:B::1.0": {
+        "lidvid": "a:b:c:d:e:B::1.0",
+        "parent_collection_lidvids": [
+          "a:b:c:d:e::1.0"
+        ],
+        "parent_bundle_lidvids": [
+          "a:b:c:d::1.0"
+        ]
+      }
+    },
+    "src1.json": {
+      "a:b:c:d:e:a::1.0": {
+        "lidvid": "a:b:c:d:e:a::1.0",
+        "parent_collection_lidvids": [
+          "a:b:c:d:e::1.1"
+        ],
+        "parent_bundle_lidvids": [
+          "a:b:c:d::1.1"
+        ]
+      }
+    },
+    "src2.json": {
+      "a:b:c:d:e:b::1.0": {
+        "lidvid": "a:b:c:d:e:b::1.0",
+        "parent_collection_lidvids": [
+          "a:b:c:d:e::1.2"
+        ],
+        "parent_bundle_lidvids": [
+          "a:b:c:d::1.2"
+        ]
+      }
+    }
+  }
+}

--- a/tests/pds/registrysweepers/test_ancestry.py
+++ b/tests/pds/registrysweepers/test_ancestry.py
@@ -314,7 +314,9 @@ class AncestryMemoryOptimizedTestCase(unittest.TestCase):
         collection1_1 = PdsLidVid.from_string("a:b:c:bundle:first_collection::1.0")
         collection1_2 = PdsLidVid.from_string("a:b:c:bundle:first_collection::2.0")
         collection2_1 = PdsLidVid.from_string("a:b:c:bundle:second_collection::1.0")
-        collections = {collection1_1, collection1_2, collection2_1}
+        overlapping_collections = {collection1_1, collection2_1}
+        nonoverlapping_collections = {collection1_2}
+        collections = overlapping_collections.union(nonoverlapping_collections)
 
         product1_1 = PdsLidVid.from_string("a:b:c:bundle:first_collection:first_unique_product::1.0")
         product1_2 = PdsLidVid.from_string("a:b:c:bundle:first_collection:first_unique_product::2.0")
@@ -344,7 +346,7 @@ class AncestryMemoryOptimizedTestCase(unittest.TestCase):
                 lidvid=product2_1, parent_bundle_lidvids={bundle}, parent_collection_lidvids={collection2_1}
             ),
             AncestryRecord(
-                lidvid=product_common, parent_bundle_lidvids={bundle}, parent_collection_lidvids=collections
+                lidvid=product_common, parent_bundle_lidvids={bundle}, parent_collection_lidvids=overlapping_collections
             ),
         ]
 

--- a/tests/pds/registrysweepers/test_ancestry.py
+++ b/tests/pds/registrysweepers/test_ancestry.py
@@ -8,6 +8,7 @@ from typing import Tuple
 from pds.registrysweepers import ancestry
 from pds.registrysweepers.ancestry import AncestryRecord
 from pds.registrysweepers.ancestry import get_collection_ancestry_records
+from pds.registrysweepers.ancestry import get_nonaggregate_ancestry_records
 from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
 
 from tests.mocks.registryquerymock import RegistryQueryMock
@@ -294,6 +295,61 @@ class AncestryLegacyTypesTestCase(unittest.TestCase):
             parent_bundle_lidvids={expected_parent_bundle_lidvid},
         )
         self.assertEqual(expected_record, collection_ancestry_records[0])
+
+
+class AncestryMemoryOptimizedTestCase(unittest.TestCase):
+    input_file_path = os.path.abspath(
+        "./tests/pds/registrysweepers/test_ancestry_mock_AncestryMemoryOptimizedTestCase.json"
+    )
+    registry_query_mock = RegistryQueryMock(input_file_path)
+
+    def test_ancestor_reference_aggregation(self):
+        """
+        Test that memory-optimized reimplementation of get_nonaggregate_ancestry_records() correctly aggregates
+        references from queries.
+        Does NOT test correctness those queries themselves, though those have been tested manually and are simple.
+        """
+        bundle = PdsLidVid.from_string("a:b:c:bundle::1.0")
+
+        collection1_1 = PdsLidVid.from_string("a:b:c:bundle:first_collection::1.0")
+        collection1_2 = PdsLidVid.from_string("a:b:c:bundle:first_collection::2.0")
+        collection2_1 = PdsLidVid.from_string("a:b:c:bundle:second_collection::1.0")
+        collections = {collection1_1, collection1_2, collection2_1}
+
+        product1_1 = PdsLidVid.from_string("a:b:c:bundle:first_collection:first_unique_product::1.0")
+        product1_2 = PdsLidVid.from_string("a:b:c:bundle:first_collection:first_unique_product::2.0")
+        product2_1 = PdsLidVid.from_string("a:b:c:bundle:first_collection:second_unique_product::1.0")
+        product_common = PdsLidVid.from_string("a:b:c:bundle:first_collection:overlapping_product::1.0")
+
+        collection_ancestry_records = [AncestryRecord(lidvid=c, parent_bundle_lidvids={bundle}) for c in collections]
+
+        query_mock_f = self.registry_query_mock.get_mocked_query
+        collection_ancestry_records = set(
+            get_nonaggregate_ancestry_records(None, collection_ancestry_records, query_mock_f)
+        )
+
+        self.assertEqual(
+            4,
+            len(collection_ancestry_records),
+            msg="Correct number of updates is produced.  Assumes no duplicate updates.",
+        )
+        expected_records = [
+            AncestryRecord(
+                lidvid=product1_1, parent_bundle_lidvids={bundle}, parent_collection_lidvids={collection1_1}
+            ),
+            AncestryRecord(
+                lidvid=product1_2, parent_bundle_lidvids={bundle}, parent_collection_lidvids={collection1_2}
+            ),
+            AncestryRecord(
+                lidvid=product2_1, parent_bundle_lidvids={bundle}, parent_collection_lidvids={collection2_1}
+            ),
+            AncestryRecord(
+                lidvid=product_common, parent_bundle_lidvids={bundle}, parent_collection_lidvids=collections
+            ),
+        ]
+
+        for record in expected_records:
+            self.assertIn(record, collection_ancestry_records, msg=f"Expected record is produced")
 
 
 if __name__ == "__main__":

--- a/tests/pds/registrysweepers/test_ancestry_mock_AncestryMemoryOptimizedTestCase.json
+++ b/tests/pds/registrysweepers/test_ancestry_mock_AncestryMemoryOptimizedTestCase.json
@@ -1,0 +1,70 @@
+{
+  "--note": [
+    "Example history for three versioned-collection instances (two different collections, one with two versions).",
+    "Each collection has one unique non-agg product, and another which is shared with both other collections.",
+    "This tests the new memory-optimized implementation of ancestry.generation.get_nonaggregate_ancestry_records() to",
+    "ensure that it is accumulating correctly.",
+    "",
+    "Currently, does not incorporate a collection which shares no common elements with any other collections (use 1_2 for this in future)",
+    "",
+    "The overlapping-collection query which underpins the new implementation must be tested manually, separately."
+    ],
+  "get_nonaggregate_ancestry_records": [
+    {
+      "_source": {
+        "collection_lidvid": "a:b:c:bundle:first_collection::1.0",
+        "product_lidvid": [
+          "a:b:c:bundle:first_collection:first_unique_product::1.0",
+          "a:b:c:bundle:first_collection:overlapping_product::1.0"
+        ]
+      }
+    },
+    {
+      "_source": {
+        "collection_lidvid": "a:b:c:bundle:first_collection::2.0",
+        "product_lidvid": [
+          "a:b:c:bundle:first_collection:first_unique_product::2.0",
+          "a:b:c:bundle:first_collection:overlapping_product::1.0"
+        ]
+      }
+    },
+    {
+      "_source": {
+        "collection_lidvid": "a:b:c:bundle:second_collection::1.0",
+        "product_lidvid": [
+          "a:b:c:bundle:first_collection:second_unique_product::1.0",
+          "a:b:c:bundle:first_collection:overlapping_product::1.0"
+        ]
+      }
+    }
+  ],
+  "get_collections_with_shared_products_query": [
+    {
+      "_source": {
+        "collection_lidvid": "a:b:c:bundle:first_collection::1.0",
+        "product_lidvid": [
+          "a:b:c:bundle:first_collection:first_unique_product::1.0",
+          "a:b:c:bundle:first_collection:overlapping_product::1.0"
+        ]
+      }
+    },
+    {
+      "_source": {
+        "collection_lidvid": "a:b:c:bundle:first_collection::2.0",
+        "product_lidvid": [
+          "a:b:c:bundle:first_collection:first_unique_product::2.0",
+          "a:b:c:bundle:first_collection:overlapping_product::1.0"
+        ]
+      }
+    },
+    {
+      "_source": {
+        "collection_lidvid": "a:b:c:bundle:second_collection::1.0",
+        "product_lidvid": [
+          "a:b:c:bundle:first_collection:second_unique_product::1.0",
+          "a:b:c:bundle:first_collection:overlapping_product::1.0"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/pds/registrysweepers/test_ancestry_mock_AncestryMemoryOptimizedTestCase.json
+++ b/tests/pds/registrysweepers/test_ancestry_mock_AncestryMemoryOptimizedTestCase.json
@@ -5,8 +5,6 @@
     "This tests the new memory-optimized implementation of ancestry.generation.get_nonaggregate_ancestry_records() to",
     "ensure that it is accumulating correctly.",
     "",
-    "Currently, does not incorporate a collection which shares no common elements with any other collections (use 1_2 for this in future)",
-    "",
     "The overlapping-collection query which underpins the new implementation must be tested manually, separately."
     ],
   "get_nonaggregate_ancestry_records": [
@@ -23,8 +21,7 @@
       "_source": {
         "collection_lidvid": "a:b:c:bundle:first_collection::2.0",
         "product_lidvid": [
-          "a:b:c:bundle:first_collection:first_unique_product::2.0",
-          "a:b:c:bundle:first_collection:overlapping_product::1.0"
+          "a:b:c:bundle:first_collection:first_unique_product::2.0"
         ]
       }
     },
@@ -52,8 +49,7 @@
       "_source": {
         "collection_lidvid": "a:b:c:bundle:first_collection::2.0",
         "product_lidvid": [
-          "a:b:c:bundle:first_collection:first_unique_product::2.0",
-          "a:b:c:bundle:first_collection:overlapping_product::1.0"
+          "a:b:c:bundle:first_collection:first_unique_product::2.0"
         ]
       }
     },

--- a/tests/pds/registrysweepers/utils/test_misc.py
+++ b/tests/pds/registrysweepers/utils/test_misc.py
@@ -1,28 +1,28 @@
 import unittest
 
-from pds.registrysweepers.utils.misc import iterate_pages_of
+from pds.registrysweepers.utils.misc import iterate_pages_of_size
 
 
 class IteratePagesOfTestCase(unittest.TestCase):
     def test_basic_functionality(self):
         page_size = 2
         input = [1, 2, 3, 4, 5, 6]
-        output = list(iterate_pages_of(page_size, input))
+        output = list(iterate_pages_of_size(page_size, input))
         expected = [[1, 2], [3, 4], [5, 6]]
         self.assertListEqual(expected, output)
 
     def test_partial_final_page(self):
         page_size = 2
         input = [1, 2, 3]
-        output = list(iterate_pages_of(page_size, input))
+        output = list(iterate_pages_of_size(page_size, input))
         expected = [[1, 2], [3]]
         self.assertListEqual(expected, output)
 
     def test_empty_input(self):
-        self.assertEqual([], list(iterate_pages_of(1, [])))
+        self.assertEqual([], list(iterate_pages_of_size(1, [])))
 
     def test_invalid_page_size(self):
-        self.assertRaises(ValueError, lambda: list(iterate_pages_of(0, [1, 2, 3])))
+        self.assertRaises(ValueError, lambda: list(iterate_pages_of_size(0, [1, 2, 3])))
 
 
 if __name__ == "__main__":

--- a/tests/pds/registrysweepers/utils/test_misc.py
+++ b/tests/pds/registrysweepers/utils/test_misc.py
@@ -1,0 +1,29 @@
+import unittest
+
+from pds.registrysweepers.utils.misc import iterate_pages_of
+
+
+class IteratePagesOfTestCase(unittest.TestCase):
+    def test_basic_functionality(self):
+        page_size = 2
+        input = [1, 2, 3, 4, 5, 6]
+        output = list(iterate_pages_of(page_size, input))
+        expected = [[1, 2], [3, 4], [5, 6]]
+        self.assertListEqual(expected, output)
+
+    def test_partial_final_page(self):
+        page_size = 2
+        input = [1, 2, 3]
+        output = list(iterate_pages_of(page_size, input))
+        expected = [[1, 2], [3]]
+        self.assertListEqual(expected, output)
+
+    def test_empty_input(self):
+        self.assertEqual([], list(iterate_pages_of(1, [])))
+
+    def test_invalid_page_size(self):
+        self.assertRaises(ValueError, lambda: list(iterate_pages_of(0, [1, 2, 3])))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 🗒️ Summary
Implements a new chunked processing paradigm for ancestry sweeper to reduce provisioned memory requirement at the cost of some runtime speed and the need to provision enough disk space to perform swapping.  The disk dump avoids the need to hold the full ancestry history in memory to generate AncestryRecords.

Performance tuning is available via env vars `ANCESTRY_NONAGGREGATE_QUERY_PAGE_SIZE` (default 2000) and `ANCESTRY_DISK_DUMP_MEMORY_THRESHOLD` (expressed in percent, default `80`). Further details are available in ancestry.runtimeconstants.py

Performance test on en-prod resulted in ability to drop from 1vCPU and 4GB memory to 0.5vCPU and 1GB memory (cost savings of 42%), at the cost of 31% increased runtime.  Proportional benefit is expected to be significantly higher for nodes with greater quantities of data as higher memory allocations require more vCPUs, all except one of which are wasted, though this will require confirmation.  This also, critically, removes the inability to scale to large quantities of products due to finite ability to increase provisioned RAM.

## ⚙️ Test Data and/or Report
Regression tests augmented/updated/passed.  Functional tests implemented for new dump/merge behaviour to ensure production of correct update content.  Manually tested against `en-prod` with a dry-run and shown to produce equal update count to pre-PR version.  Performance-tested against `en-prod`.

~N.B. Docs are failing due to sphinx issue (locally and in github actions)~ not anymore

## ♻️ Related Issues
fixes #39 


## Ops notes

I switched ECS task definitions to use tag `stable` rather than `latest`, thinking that `latest` would automatically reference the last-pushed image (and we don't want a dev pushing a development-related tag and causing all tasks to use that by default), but this appears not to be the case.  Is `latest` a manual tag rather than something auto-generated?  If so, task definitions should be switched back to using `latest`.  @sjoshi-jpl @jordanpadams ?

@sjoshi-jpl once this is deployed to ECR, I'd recommend the following approach to tune provisioned memory/vCPUs

- provision 200GB ephemeral ECS storage
- cut vCPUs to 1, and memory to the lesser of `current-value/2` and `8GB` (max permitted for 1vCPU).  For very-small nodes, 0.25-0.5vCPUs may be warranted 
- run sweeper once - if it crashes, set env var `ANCESTRY_DISK_DUMP_MEMORY_THRESHOLD=60` and try again (you should not have to cut any further)
- when complete, look for log line like `22:43:38,074::pds.registrysweepers.ancestry.generation::INFO::On-disk swap comprised of 3 files totalling 0.3GB`
- choose provisioned ephemeral ECS storage value according to the total size logged(maybe `current*2`?)

If you're able to benchmark provisioned memory/vCPUs before/after and runtime before/after, awesome, but I understand that's annoying work.