### PR TITLE
94 - pin sphinx components/deps for compatibility with sphinx 3.2.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,8 @@ python_requires = >= 3.9
 
 [options.extras_require]
 dev =
+# later versions of alabaster require sphinx>=3.4
+    alabaster <=0.7.13
     black~=23.7.0
     flake8~=6.1.0
     flake8-bugbear~=23.7.10
@@ -61,6 +63,15 @@ dev =
     pre-commit~=3.3.3
     sphinx~=3.2.1
     sphinx-rtd-theme~=0.5.0
+
+# unclear why the following pins are necessary, but without them, versions dependent on sphinx>=5.0 are installed
+    sphinxcontrib-applehelp==1.0.4
+    sphinxcontrib-devhelp==1.0.2
+    sphinxcontrib-htmlhelp==2.0.1
+    sphinxcontrib-jsmath==1.0.1
+    sphinxcontrib-qthelp==1.0.3
+    sphinxcontrib-serializinghtml==1.1.5
+
     tox~=4.11.0
     types_requests~=2.28
     types-retry~=0.9.9.4


### PR DESCRIPTION
## 🗒️ Summary
`alabaster>=0.7.14` requires `sphinx>=3.4`
various `sphinxcontrib-*` packages are now requiring `sphinx>=5.0` - I'm confused as to why, given that they seem to be installed _by_ sphinx 3.1.2, but I won't dwell on it right now.

## ⚙️ Test Data and/or Report
Tests now pass, including docs build

## ♻️ Related Issues
resolves #94 