### PR TITLE
Fix image construction problem

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,12 +46,16 @@ ENV INSTALL_WORKDIR=/tmp/registry-sweepers
 
 COPY . $INSTALL_WORKDIR
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git
+RUN apt-get update --quiet && \
+    apt-get upgrade --quiet --yes && \
+    apt-get install --quiet --yes git gcc python3-dev
 
 RUN pip install $INSTALL_WORKDIR \
  && cp $INSTALL_WORKDIR/docker/sweepers_driver.py /usr/local/bin/ \
  && rm -r $INSTALL_WORKDIR
+
+RUN apt-get autoremove && \
+    apt-get remove --quiet --yes gcc python3-dev && \
+    rm --force --recursive /var/lib/apt/lists/*
 
 CMD ["/usr/local/bin/sweepers_driver.py"]


### PR DESCRIPTION
## 🗒️ Summary

Merge this to fix a problem with building of Docker images.

For details, see build at https://github.com/NASA-PDS/registry-sweepers/actions/runs/7549106501/job/20786456869 … the issue being that the new `psutil` dependency requires the dev environment at build time.

## ⚙️ Test Data and/or Report
```console
$ mirasol 296 % docker image build --file ./docker/Dockerfile .
[+] Building 0.0s (10/10) FINISHED                                                               docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                             0.0s
 => => transferring dockerfile: 2.64kB                                                                           0.0s
 => [internal] load .dockerignore                                                                                0.0s
 => => transferring context: 202B                                                                                0.0s
 => [internal] load metadata for docker.io/library/python:3.9-slim-bullseye                                      0.0s
 => [internal] load build context                                                                                0.0s
 => => transferring context: 2.94kB                                                                              0.0s
 => [1/5] FROM docker.io/library/python:3.9-slim-bullseye                                                        0.0s
 => CACHED [2/5] COPY . /tmp/registry-sweepers                                                                   0.0s
 => CACHED [3/5] RUN apt-get update --quiet &&     apt-get upgrade --quiet --yes &&     apt-get install --quiet  0.0s
 => CACHED [4/5] RUN pip install /tmp/registry-sweepers  && cp /tmp/registry-sweepers/docker/sweepers_driver.py  0.0s
 => CACHED [5/5] RUN apt-get autoremove &&     apt-get remove --quiet --yes gcc python3-dev &&     rm --force -  0.0s
 => exporting to image                                                                                           0.0s
 => => exporting layers                                                                                          0.0s
 => => writing image sha256:e201433ec7055f4c5e5e39baeffd0a9ee671201ab0d05f164bd402ad9896407d                     0.0s
```
## ♻️ Related Issues

N/A
