### PR TITLE
Non redundant provenance

### DIFF
--- a/docker/sweepers_driver.py
+++ b/docker/sweepers_driver.py
@@ -121,7 +121,6 @@ optional_sweepers = {
 
 args = parser.parse_args()
 
-
 # Define default sweepers to be run here, in order of execution
 sweepers = [
     repairkit.run,
@@ -136,10 +135,18 @@ for option, sweeper in optional_sweepers.items():
 sweeper_descriptions = [inspect.getmodule(f).__name__ for f in sweepers]
 log.info(f'Running sweepers: {sweeper_descriptions}')
 
-execution_begin = datetime.now()
+total_execution_begin = datetime.now()
+
+sweeper_execution_duration_strs = []
 
 for sweeper in sweepers:
+    sweeper_execution_begin = datetime.now()
     run_sweeper_f = run_factory(sweeper)
+
     run_sweeper_f()
 
-log.info(f'Sweepers successfully executed in {get_human_readable_elapsed_since(execution_begin)}')
+    sweeper_name = inspect.getmodule(sweeper).__name__
+    sweeper_execution_duration_strs.append(f'{sweeper_name}: {get_human_readable_elapsed_since(sweeper_execution_begin)}')
+
+log.info(f'Sweepers successfully executed in {get_human_readable_elapsed_since(total_execution_begin)}\n   '
+         + '\n   '.join(sweeper_execution_duration_strs))

--- a/docker/sweepers_driver.py
+++ b/docker/sweepers_driver.py
@@ -103,7 +103,7 @@ def run_factory(sweeper_f: Callable) -> Callable:
     return functools.partial(
         sweeper_f,
         client=get_opensearch_client_from_environment(verify_certs=True if not dev_mode else False),
-        log_filepath='provenance.log',
+        log_filepath='registry-sweepers.log',
         log_level=log_level
     )
 

--- a/src/pds/registrysweepers/ancestry/__init__.py
+++ b/src/pds/registrysweepers/ancestry/__init__.py
@@ -55,8 +55,17 @@ def run(
 
     if bulk_updates_sink is None:
         log.info("Ensuring metadata keys are present in database index...")
-        for metadata_key in [METADATA_PARENT_BUNDLE_KEY, METADATA_PARENT_COLLECTION_KEY]:
+        for metadata_key in [
+            METADATA_PARENT_BUNDLE_KEY,
+            METADATA_PARENT_COLLECTION_KEY,
+            SWEEPERS_ANCESTRY_VERSION_METADATA_KEY,
+        ]:
             ensure_index_mapping(client, "registry", metadata_key, "keyword")
+
+        for metadata_key in [
+            SWEEPERS_ANCESTRY_VERSION_METADATA_KEY,
+        ]:
+            ensure_index_mapping(client, "registry-refs", metadata_key, "keyword")
 
         log.info("Writing bulk updates to database...")
         write_updated_docs(client, updates)

--- a/src/pds/registrysweepers/ancestry/__init__.py
+++ b/src/pds/registrysweepers/ancestry/__init__.py
@@ -14,6 +14,8 @@ from pds.registrysweepers.ancestry.ancestryrecord import AncestryRecord
 from pds.registrysweepers.ancestry.generation import get_bundle_ancestry_records
 from pds.registrysweepers.ancestry.generation import get_collection_ancestry_records
 from pds.registrysweepers.ancestry.generation import get_nonaggregate_ancestry_records
+from pds.registrysweepers.ancestry.versioning import SWEEPERS_ANCESTRY_VERSION
+from pds.registrysweepers.ancestry.versioning import SWEEPERS_ANCESTRY_VERSION_METADATA_KEY
 from pds.registrysweepers.utils import configure_logging
 from pds.registrysweepers.utils import parse_args
 from pds.registrysweepers.utils.db import write_updated_docs
@@ -48,7 +50,8 @@ def run(
     # this avoids the potential for a bundle/collection to be metadata-marked as up-to-date when execution failed before
     # its descendants were updated (due to execution interruption, e.g. database overload)
     ancestry_records = chain(nonaggregate_records, collection_records, bundle_records)
-    updates = generate_updates(ancestry_records, ancestry_records_accumulator, bulk_updates_sink)
+    ancestry_records_to_write = filter(lambda r: not r.skip_write, ancestry_records)
+    updates = generate_updates(ancestry_records_to_write, ancestry_records_accumulator, bulk_updates_sink)
 
     if bulk_updates_sink is None:
         log.info("Ensuring metadata keys are present in database index...")

--- a/src/pds/registrysweepers/ancestry/__init__.py
+++ b/src/pds/registrysweepers/ancestry/__init__.py
@@ -87,6 +87,7 @@ def generate_updates(
         update_content = {
             METADATA_PARENT_BUNDLE_KEY: [str(id) for id in record.parent_bundle_lidvids],
             METADATA_PARENT_COLLECTION_KEY: [str(id) for id in record.parent_collection_lidvids],
+            SWEEPERS_ANCESTRY_VERSION_METADATA_KEY: int(SWEEPERS_ANCESTRY_VERSION),
         }
 
         # Tee the stream of bulk update KVs into the accumulator, if one was provided (functional testing).

--- a/src/pds/registrysweepers/ancestry/__init__.py
+++ b/src/pds/registrysweepers/ancestry/__init__.py
@@ -69,7 +69,11 @@ def run(
             ensure_index_mapping(client, "registry-refs", metadata_key, "keyword")
 
         log.info("Writing bulk updates to database...")
-        write_updated_docs(client, updates)
+        write_updated_docs(
+            client,
+            updates,
+            index_name="registry",
+        )
     else:
         # consume generator to dump bulk updates to sink
         for _ in updates:

--- a/src/pds/registrysweepers/ancestry/generation.py
+++ b/src/pds/registrysweepers/ancestry/generation.py
@@ -295,7 +295,10 @@ def _get_nonaggregate_ancestry_records_with_chunking(
     make_history_serializable(nonaggregate_ancestry_records_by_lidvid)
     chunk_size_max = max(chunk_size_max, sys.getsizeof(nonaggregate_ancestry_records_by_lidvid))
     for history_dict in nonaggregate_ancestry_records_by_lidvid.values():
-        yield AncestryRecord.from_dict(history_dict)
+        try:
+            yield AncestryRecord.from_dict(history_dict)
+        except ValueError as err:
+            log.error(err)
     del nonaggregate_ancestry_records_by_lidvid
     gc.collect()
 

--- a/src/pds/registrysweepers/ancestry/queries.py
+++ b/src/pds/registrysweepers/ancestry/queries.py
@@ -35,7 +35,7 @@ def product_class_query_factory(cls: ProductClass) -> Dict:
 
 def get_bundle_ancestry_records_query(client: OpenSearch, db_mock: DbMockTypeDef = None) -> Iterable[Dict]:
     query = product_class_query_factory(ProductClass.BUNDLE)
-    _source = {"includes": ["lidvid"]}
+    _source = {"includes": ["lidvid", SWEEPERS_ANCESTRY_VERSION_METADATA_KEY]}
     query_f = query_registry_db_or_mock(db_mock, "get_bundle_ancestry_records", use_search_after=True)
     docs = query_f(client, query, _source)
 
@@ -56,7 +56,7 @@ def get_collection_ancestry_records_collections_query(
 ) -> Iterable[Dict]:
     # Query the registry for all collection identifiers
     query = product_class_query_factory(ProductClass.COLLECTION)
-    _source = {"includes": ["lidvid", "alternate_ids"]}
+    _source = {"includes": ["lidvid", "alternate_ids", SWEEPERS_ANCESTRY_VERSION_METADATA_KEY]}
     query_f = query_registry_db_or_mock(db_mock, "get_collection_ancestry_records_collections", use_search_after=True)
     docs = query_f(client, query, _source)
 

--- a/src/pds/registrysweepers/ancestry/queries.py
+++ b/src/pds/registrysweepers/ancestry/queries.py
@@ -39,7 +39,7 @@ def get_bundle_ancestry_records_query(client: OpenSearch, db_mock: DbMockTypeDef
     query = product_class_query_factory(ProductClass.BUNDLE)
     _source = {"includes": ["lidvid", SWEEPERS_ANCESTRY_VERSION_METADATA_KEY]}
     query_f = query_registry_db_or_mock(db_mock, "get_bundle_ancestry_records", use_search_after=True)
-    docs = query_f(client, query, _source)
+    docs = query_f(client, "registry", query, _source)
 
     return docs
 
@@ -48,7 +48,7 @@ def get_collection_ancestry_records_bundles_query(client: OpenSearch, db_mock: D
     query = product_class_query_factory(ProductClass.BUNDLE)
     _source = {"includes": ["lidvid", "ref_lid_collection"]}
     query_f = query_registry_db_or_mock(db_mock, "get_collection_ancestry_records_bundles", use_search_after=True)
-    docs = query_f(client, query, _source)
+    docs = query_f(client, "registry", query, _source)
 
     return docs
 
@@ -60,7 +60,7 @@ def get_collection_ancestry_records_collections_query(
     query = product_class_query_factory(ProductClass.COLLECTION)
     _source = {"includes": ["lidvid", "alternate_ids", SWEEPERS_ANCESTRY_VERSION_METADATA_KEY]}
     query_f = query_registry_db_or_mock(db_mock, "get_collection_ancestry_records_collections", use_search_after=True)
-    docs = query_f(client, query, _source)
+    docs = query_f(client, "registry", query, _source)
 
     return docs
 
@@ -81,9 +81,9 @@ def get_nonaggregate_ancestry_records_query(client: OpenSearch, registry_db_mock
     # each document will have many product lidvids, so a smaller page size is warranted here
     docs = query_f(
         client,
+        "registry-refs",
         query,
         _source,
-        index_name="registry-refs",
         page_size=AncestryRuntimeConstants.nonaggregate_ancestry_records_query_page_size,
         request_timeout_seconds=30,
         sort_fields=["collection_lidvid", "batch_id"],
@@ -109,6 +109,6 @@ def get_orphaned_documents(client: OpenSearch, registry_db_mock: DbMockTypeDef, 
         ["collection_lidvid", "batch_id"] if index_name == "registry-refs" else None
     )  # use default for registry
 
-    docs = query_f(client, query, _source, index_name=index_name, sort_fields=sort_fields_override)
+    docs = query_f(client, index_name, query, _source, sort_fields=sort_fields_override)
 
     return docs

--- a/src/pds/registrysweepers/ancestry/queries.py
+++ b/src/pds/registrysweepers/ancestry/queries.py
@@ -8,6 +8,8 @@ from typing import Optional
 
 from opensearchpy import OpenSearch
 from pds.registrysweepers.ancestry.runtimeconstants import AncestryRuntimeConstants
+from pds.registrysweepers.ancestry.versioning import SWEEPERS_ANCESTRY_VERSION
+from pds.registrysweepers.ancestry.versioning import SWEEPERS_ANCESTRY_VERSION_METADATA_KEY
 from pds.registrysweepers.utils.db import query_registry_db_or_mock
 
 log = logging.getLogger(__name__)
@@ -65,7 +67,14 @@ def get_collection_ancestry_records_collections_query(
 
 def get_nonaggregate_ancestry_records_query(client: OpenSearch, registry_db_mock: DbMockTypeDef) -> Iterable[Dict]:
     # Query the registry-refs index for the contents of all collections
-    query: Dict = {"query": {"match_all": {}}, "seq_no_primary_term": True}
+    query: Dict = {
+        "query": {
+            "bool": {
+                "must_not": [{"range": {SWEEPERS_ANCESTRY_VERSION_METADATA_KEY: {"gte": SWEEPERS_ANCESTRY_VERSION}}}]
+            }
+        },
+        "seq_no_primary_term": True,
+    }
     _source = {"includes": ["collection_lidvid", "batch_id", "product_lidvid"]}
     query_f = query_registry_db_or_mock(registry_db_mock, "get_nonaggregate_ancestry_records", use_search_after=True)
 

--- a/src/pds/registrysweepers/ancestry/queries.py
+++ b/src/pds/registrysweepers/ancestry/queries.py
@@ -65,7 +65,7 @@ def get_collection_ancestry_records_collections_query(
 
 def get_nonaggregate_ancestry_records_query(client: OpenSearch, registry_db_mock: DbMockTypeDef) -> Iterable[Dict]:
     # Query the registry-refs index for the contents of all collections
-    query: Dict = {"query": {"match_all": {}}}
+    query: Dict = {"query": {"match_all": {}}, "seq_no_primary_term": True}
     _source = {"includes": ["collection_lidvid", "batch_id", "product_lidvid"]}
     query_f = query_registry_db_or_mock(registry_db_mock, "get_nonaggregate_ancestry_records", use_search_after=True)
 

--- a/src/pds/registrysweepers/ancestry/versioning.py
+++ b/src/pds/registrysweepers/ancestry/versioning.py
@@ -1,0 +1,7 @@
+# Defines constants used for versioning updated documents with the in-use version of sweepers
+# SWEEPERS_VERSION must be incremented any time sweepers is changed in a way which requires reprocessing of
+# previously-processed data
+from pds.registrysweepers.utils.misc import get_sweeper_version_metadata_key
+
+SWEEPERS_ANCESTRY_VERSION = 1
+SWEEPERS_ANCESTRY_VERSION_METADATA_KEY = get_sweeper_version_metadata_key("ancestry")

--- a/src/pds/registrysweepers/provenance/__init__.py
+++ b/src/pds/registrysweepers/provenance/__init__.py
@@ -110,6 +110,9 @@ def link_records_in_chain(record_chain: List[ProvenanceRecord]):
     """
     Given a List of ProvenanceRecords sharing the same LID, sort the list and create all elements' successor links
     """
+
+    # this can theoretically be disabled for a minor performance improvement as records are already sorted when queried
+    # but the benefit is likely to be minimal, and it's safer not to assume
     record_chain.sort(key=lambda record: record.lidvid)
 
     for i in range(len(record_chain) - 1):

--- a/src/pds/registrysweepers/provenance/__init__.py
+++ b/src/pds/registrysweepers/provenance/__init__.py
@@ -70,7 +70,7 @@ def get_records(client: OpenSearch) -> Iterable[ProvenanceRecord]:
     query = {
         "query": {"bool": {"must": [{"terms": {"ops:Tracking_Meta/ops:archive_status": ["archived", "certified"]}}]}}
     }
-    _source = {"includes": ["lidvid", METADATA_SUCCESSOR_KEY]}
+    _source = {"includes": ["lidvid", METADATA_SUCCESSOR_KEY, SWEEPERS_PROVENANCE_VERSION_METADATA_KEY]}
 
     docs = query_registry_db_with_search_after(client, "registry", query, _source)
 

--- a/src/pds/registrysweepers/provenance/__init__.py
+++ b/src/pds/registrysweepers/provenance/__init__.py
@@ -75,7 +75,11 @@ def run(
     successors = get_successors_by_lidvid(extant_lidvids)
     updates = generate_updates(successors)
 
-    write_updated_docs(client, updates)
+    write_updated_docs(
+        client,
+        updates,
+        index_name="registry",
+    )
 
     log.info("Completed provenance sweeper processing!")
 

--- a/src/pds/registrysweepers/provenance/__init__.py
+++ b/src/pds/registrysweepers/provenance/__init__.py
@@ -148,7 +148,7 @@ def generate_updates(records: Iterable[ProvenanceRecord]) -> Iterable[Update]:
     skipped_count = 0
     for record in records:
         update_content = {
-            METADATA_SUCCESSOR_KEY: str(record.successor),
+            METADATA_SUCCESSOR_KEY: str(record.successor) if record.successor else None,
             SWEEPERS_PROVENANCE_VERSION_METADATA_KEY: SWEEPERS_PROVENANCE_VERSION,
         }
 

--- a/src/pds/registrysweepers/provenance/constants.py
+++ b/src/pds/registrysweepers/provenance/constants.py
@@ -1,0 +1,1 @@
+METADATA_SUCCESSOR_KEY = "ops:Provenance/ops:superseded_by"

--- a/src/pds/registrysweepers/provenance/provenancerecord.py
+++ b/src/pds/registrysweepers/provenance/provenancerecord.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Dict
+from typing import Optional
+
+from pds.registrysweepers.provenance.constants import METADATA_SUCCESSOR_KEY
+from pds.registrysweepers.provenance.versioning import SWEEPERS_PROVENANCE_VERSION
+from pds.registrysweepers.provenance.versioning import SWEEPERS_PROVENANCE_VERSION_METADATA_KEY
+from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
+
+
+class ProvenanceRecord:
+    lidvid: PdsLidVid
+    _successor: Optional[PdsLidVid]
+    skip_write: bool
+
+    def __init__(self, lidvid: PdsLidVid, successor: Optional[PdsLidVid], skip_write: bool = False):
+        self.lidvid = lidvid
+        self._successor = successor
+        self.skip_write = skip_write
+
+    @property
+    def successor(self) -> Optional[PdsLidVid]:
+        return self._successor
+
+    def set_successor(self, successor: PdsLidVid):
+        if successor != self._successor:
+            self._successor = successor
+            self.skip_write = False
+
+    @staticmethod
+    def from_source(_source: Dict) -> ProvenanceRecord:
+        if METADATA_SUCCESSOR_KEY in _source:
+            successor = PdsLidVid.from_string(_source[METADATA_SUCCESSOR_KEY])
+        else:
+            successor = None
+        skip_write = _source.get(SWEEPERS_PROVENANCE_VERSION_METADATA_KEY, 0) >= SWEEPERS_PROVENANCE_VERSION
+        return ProvenanceRecord(
+            lidvid=PdsLidVid.from_string(_source["lidvid"]), successor=successor, skip_write=skip_write
+        )
+
+    @staticmethod
+    def from_doc(doc: Dict) -> ProvenanceRecord:
+        return ProvenanceRecord.from_source(doc["_source"])

--- a/src/pds/registrysweepers/provenance/provenancerecord.py
+++ b/src/pds/registrysweepers/provenance/provenancerecord.py
@@ -30,7 +30,7 @@ class ProvenanceRecord:
 
     @staticmethod
     def from_source(_source: Dict) -> ProvenanceRecord:
-        if METADATA_SUCCESSOR_KEY in _source:
+        if METADATA_SUCCESSOR_KEY in _source and _source[METADATA_SUCCESSOR_KEY] is not None:
             successor = PdsLidVid.from_string(_source[METADATA_SUCCESSOR_KEY])
         else:
             successor = None

--- a/src/pds/registrysweepers/provenance/versioning.py
+++ b/src/pds/registrysweepers/provenance/versioning.py
@@ -1,0 +1,7 @@
+# Defines constants used for versioning updated documents with the in-use version of sweepers
+# SWEEPERS_VERSION must be incremented any time sweepers is changed in a way which requires reprocessing of
+# previously-processed data
+from pds.registrysweepers.utils.misc import get_sweeper_version_metadata_key
+
+SWEEPERS_PROVENANCE_VERSION = 1
+SWEEPERS_PROVENANCE_VERSION_METADATA_KEY = get_sweeper_version_metadata_key("provenance")

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -100,7 +100,7 @@ def run(
     all_docs = query_registry_db(client, unprocessed_docs_query, {}, page_size=1000)
     updates = generate_updates(all_docs, SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY, SWEEPERS_REPAIRKIT_VERSION)
     ensure_index_mapping(client, "registry", SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY, "integer")
-    write_updated_docs(client, updates, bulk_chunk_max_update_count=20000)
+    write_updated_docs(client, updates, index_name="registry", bulk_chunk_max_update_count=20000)
 
     log.info("Repairkit sweeper processing complete!")
 

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -97,7 +97,7 @@ def run(
 
     # page_size and bulk_chunk_max_update_count constraints are necessary to avoid choking nodes with very-large docs
     # i.e. ATM and GEO
-    all_docs = query_registry_db(client, unprocessed_docs_query, {}, page_size=1000)
+    all_docs = query_registry_db(client, "registry", unprocessed_docs_query, {}, page_size=1000)
     updates = generate_updates(all_docs, SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY, SWEEPERS_REPAIRKIT_VERSION)
     ensure_index_mapping(client, "registry", SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY, "integer")
     write_updated_docs(client, updates, index_name="registry", bulk_chunk_max_update_count=20000)

--- a/src/pds/registrysweepers/repairkit/versioning.py
+++ b/src/pds/registrysweepers/repairkit/versioning.py
@@ -1,5 +1,7 @@
 # Defines constants used for versioning updated documents with the in-use version of sweepers
 # SWEEPERS_VERSION must be incremented any time sweepers is changed in a way which requires reprocessing of
 # previously-processed data
+from pds.registrysweepers.utils.misc import get_sweeper_version_metadata_key
+
 SWEEPERS_REPAIRKIT_VERSION = 3
-SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY = "ops:Provenance/ops:registry_sweepers_repairkit_version"
+SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY = get_sweeper_version_metadata_key("repairkit")

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -2,6 +2,7 @@ import json
 import logging
 import math
 import sys
+from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Iterable
@@ -284,7 +285,12 @@ def write_updated_docs(
 
 def update_as_statements(update: Update) -> Iterable[str]:
     """Given an Update, convert it to an ElasticSearch-style set of request body content strings"""
-    update_objs = [{"update": {"_id": update.id}}, {"doc": update.content}]
+    metadata_statement: Dict[str, Any] = {"update": {"_id": update.id}}
+    if update.has_versioning_information():
+        metadata_statement["if_primary_term"] = update.primary_term
+        metadata_statement["if_seq_no"] = update.seq_no
+    content_statement = {"doc": update.content}
+    update_objs = [metadata_statement, content_statement]
     updates_strs = [json.dumps(obj) for obj in update_objs]
     return updates_strs
 

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -240,7 +240,7 @@ def query_registry_db_or_mock(
 def write_updated_docs(
     client: OpenSearch,
     updates: Iterable[Update],
-    index_name: str = "registry",
+    index_name: str,
     bulk_chunk_max_update_count: Union[int, None] = None,
 ):
     log.info("Updating a lazily-generated collection of product documents...")

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -22,9 +22,9 @@ log = logging.getLogger(__name__)
 
 def query_registry_db(
     client: OpenSearch,
+    index_name: str,
     query: Dict,
     _source: Dict,
-    index_name: str = "registry",
     page_size: int = 10000,
     scroll_keepalive_minutes: int = 10,
     request_timeout_seconds: int = 20,
@@ -119,9 +119,9 @@ def query_registry_db(
 
 def query_registry_db_with_search_after(
     client: OpenSearch,
+    index_name: str,
     query: Dict,
     _source: Dict,
-    index_name: str = "registry",
     page_size: int = 10000,
     sort_fields: Union[List[str], None] = None,
     request_timeout_seconds: int = 20,
@@ -214,15 +214,17 @@ def query_registry_db_with_search_after(
 
 
 def query_registry_db_or_mock(
-    mock_f: Optional[Callable[[str], Iterable[Dict]]], mock_query_id: str, use_search_after: bool = False
+    mock_f: Optional[Callable[[str], Iterable[Dict]]],
+    mock_query_id: str,
+    use_search_after: bool = False,
 ):
     if mock_f is not None:
 
         def mock_wrapper(
             client: OpenSearch,
+            index_name: str,
             query: Dict,
             _source: Dict,
-            index_name: str = "registry",
             page_size: int = 10000,
             scroll_validity_duration_minutes: int = 10,
             request_timeout_seconds: int = 20,
@@ -372,6 +374,6 @@ def get_extant_lidvids(client: OpenSearch) -> Iterable[str]:
     }
     _source = {"includes": ["lidvid"]}
 
-    results = query_registry_db(client, query, _source, scroll_keepalive_minutes=1)
+    results = query_registry_db(client, "registry", query, _source, scroll_keepalive_minutes=1)
 
     return map(lambda doc: doc["_source"]["lidvid"], results)

--- a/src/pds/registrysweepers/utils/db/update.py
+++ b/src/pds/registrysweepers/utils/db/update.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict
+from typing import Union
 
 
 @dataclass
@@ -8,3 +9,18 @@ class Update:
 
     id: str
     content: Dict
+
+    # These are used for version conflict detection in ES/OpenSearch
+    # see: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/optimistic-concurrency-control.html
+    primary_term: Union[int, None] = None
+    seq_no: Union[int, None] = None
+
+    def has_versioning_information(self) -> bool:
+        has_primary_term = self.primary_term is not None
+        has_sequence_number = self.seq_no is not None
+        has_either = any((has_primary_term, has_sequence_number))
+        has_both = all((has_primary_term, has_sequence_number))
+        if has_either and not has_both:
+            raise ValueError("if either of primary_term, seq_no is provided, both must be provided")
+
+        return has_both

--- a/tests/pds/registrysweepers/test_ancestry.py
+++ b/tests/pds/registrysweepers/test_ancestry.py
@@ -9,6 +9,8 @@ from pds.registrysweepers import ancestry
 from pds.registrysweepers.ancestry import AncestryRecord
 from pds.registrysweepers.ancestry import get_collection_ancestry_records
 from pds.registrysweepers.ancestry import get_nonaggregate_ancestry_records
+from pds.registrysweepers.ancestry import SWEEPERS_ANCESTRY_VERSION
+from pds.registrysweepers.ancestry import SWEEPERS_ANCESTRY_VERSION_METADATA_KEY
 from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
 
 from tests.mocks.registryquerymock import RegistryQueryMock
@@ -120,6 +122,8 @@ class AncestryBasicTestCase(unittest.TestCase):
                 set(update["ops:Provenance/ops:parent_collection_identifier"]),
             )
 
+            self.assertEqual(SWEEPERS_ANCESTRY_VERSION, update[SWEEPERS_ANCESTRY_VERSION_METADATA_KEY])
+
         for doc_id, update in self.bulk_updates:
             record = self.records_by_lidvid_str[doc_id]
             self.assertEqual(
@@ -130,6 +134,8 @@ class AncestryBasicTestCase(unittest.TestCase):
                 set(update["ops:Provenance/ops:parent_collection_identifier"]),
                 set(str(lidvid) for lidvid in record.parent_collection_lidvids),
             )
+
+            self.assertEqual(SWEEPERS_ANCESTRY_VERSION, update[SWEEPERS_ANCESTRY_VERSION_METADATA_KEY])
 
 
 class AncestryAlternateIdsTestCase(unittest.TestCase):

--- a/tests/pds/registrysweepers/test_ancestry_mock_AncestryAlternateIdsTestCase.json
+++ b/tests/pds/registrysweepers/test_ancestry_mock_AncestryAlternateIdsTestCase.json
@@ -184,5 +184,6 @@
         ]
       }
     }
-  ]
+  ],
+  "get_orphaned_ancestry_docs": []
 }

--- a/tests/pds/registrysweepers/test_ancestry_mock_AncestryFunctionalTestCase.json
+++ b/tests/pds/registrysweepers/test_ancestry_mock_AncestryFunctionalTestCase.json
@@ -92,5 +92,6 @@
         ]
       }
     }
-  ]
+  ],
+  "get_orphaned_ancestry_docs": []
 }

--- a/tests/pds/registrysweepers/test_ancestry_mock_AncestryMalformedDocsTestCase.json
+++ b/tests/pds/registrysweepers/test_ancestry_mock_AncestryMalformedDocsTestCase.json
@@ -88,5 +88,6 @@
         "_": "example of record with missing 'product_lidvid' field"
       }
     }
-  ]
+  ],
+  "get_orphaned_ancestry_docs": []
 }


### PR DESCRIPTION
Rebased on #100 - consider only commit 3f94d339edc53d38098b01117c291655bab90266

## 🗒️ Summary
Implements #92 

Modifies behaviour in that now, the latest version of a product will be assigned `"ops:Provenance/ops:superseded_by": null` rather than not having the attribute assigned at all.

Implements software-version-based reprocessing avoidance, as already exists for repairkit and ancestry.

Reads all documents, builds version chains for distinct LIDs, drops all singleton products (as no links exist), builds links, tainting any products with changed successor data, then produces updates, skipping up-to-date records unless they have been tainted.

## ⚙️ Test Data and/or Report
Functional tests pass, but none are relevant to provenance, per #13
Manually tested, comparing updates produced before/after change.
 
## ♻️ Related Issues
fixes #92 