### PR TITLE
91 - improve performance when logging ancestry orphaned documents  

### DIFF
--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -377,3 +377,10 @@ def get_extant_lidvids(client: OpenSearch) -> Iterable[str]:
     results = query_registry_db(client, "registry", query, _source, scroll_keepalive_minutes=1)
 
     return map(lambda doc: doc["_source"]["lidvid"], results)
+
+
+@retry(tries=6, delay=15, backoff=2, logger=log)
+def get_query_hits_count(client: OpenSearch, index_name: str, query: Dict) -> int:
+    response = client.search(index=index_name, body=query, size=0, _source_includes=[], track_total_hits=True)
+
+    return response["hits"]["total"]["value"]


### PR DESCRIPTION
## 🗒️ Summary
Previously, orphaned ancestry documents would be enumerated and logged at all logging levels.  This could take many minutes, where the sweepers run would otherwise take under one second.

When debug logging is not enabled, this enumeration will be replaced by a placeholder.

N.B. there is a little spaghetti (see new TODO).  I will open a ticket to address this at a later date, but the RoI is not high enough to delay deployment of this improvement.

## ⚙️ Test Data and/or Report
Tests pass

## ♻️ Related Issues
Addresses #91 improves #100 

