### PR TITLE
Publish stable Docker image corresponding to release/X.Y.Z tag

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -47,13 +47,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: 💳 Checkout
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     lfs: true
                     token: ${{secrets.ADMIN_GITHUB_TOKEN}}
                     fetch-depth: 0
             -   name: 💵 Python Cache
-                uses: actions/cache@v3
+                uses: actions/cache@v4
                 with:
                     path: ~/.cache/pip
                     # The "key" used to indicate a set of cached files is the operating system runner
@@ -62,18 +62,15 @@ jobs:
                     key: pds-${{runner.os}}-py-${{hashFiles('**/*.whl')}}
                     # To restore a set of files, we only need to match a prefix of the saved key.
                     restore-keys: pds-${{runner.os}}-py-
-            -   name: 🫙 Docker Image Tag Determination
-                id: docker_tag_determination
-                run: echo "::set-output name=image_tag::$(cat ./src/pds/registrysweepers/VERSION.txt)"
             -   name: 💳 Docker Hub Identification
-                uses: docker/login-action@v2
+                uses: docker/login-action@v3
                 with:
                     username: ${{secrets.DOCKERHUB_USERNAME}}
                     password: ${{secrets.DOCKERHUB_TOKEN}}
             -   name: 🎰 QEMU Multiple Machine Emulation
-                uses: docker/setup-qemu-action@v2
+                uses: docker/setup-qemu-action@v3
             -   name: 🚢 Docker Buildx
-                uses: docker/setup-buildx-action@v2
+                uses: docker/setup-buildx-action@v3
             -   name: 🤠 Roundup
                 uses: NASA-PDS/roundup-action@stable
                 with:
@@ -82,8 +79,20 @@ jobs:
                     pypi_username: ${{secrets.PYPI_USERNAME}}
                     pypi_password: ${{secrets.PYPI_PASSWORD}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
+            # At this point, the Roundup as published release/X.Y.Z to GitHub and PyPI and advanced
+            # the VERSION.txt file to X.Y+1.Z, so for Docker we need to decrement the minor version
+            # number by 1.
+            -   name: 🫙 Docker Image Tag Determination
+                id: docker_tag_determination
+                run: |
+                    roundup_version=$(cat ./src/pds/registrysweepers/VERSION.txt)
+                    IFS='.' read -ra parts <<< "$roundup_version"
+                    minor="${parts[1]}"
+                    ((minor--))
+                    docker_version="${parts[0]}.${minor}.${parts[2]}"
+                    echo "image_tag=${docker_version}" >> $GITHUB_OUTPUT
             -   name: 🧱 Image Construction and Publication
-                uses: docker/build-push-action@v3
+                uses: docker/build-push-action@v5
                 with:
                     context: ./
                     file: ./docker/Dockerfile

--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -79,18 +79,11 @@ jobs:
                     pypi_username: ${{secrets.PYPI_USERNAME}}
                     pypi_password: ${{secrets.PYPI_PASSWORD}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
-            # At this point, the Roundup as published release/X.Y.Z to GitHub and PyPI and advanced
-            # the VERSION.txt file to X.Y+1.Z, so for Docker we need to decrement the minor version
-            # number by 1.
             -   name: 🫙 Docker Image Tag Determination
                 id: docker_tag_determination
                 run: |
-                    roundup_version=$(cat ./src/pds/registrysweepers/VERSION.txt)
-                    IFS='.' read -ra parts <<< "$roundup_version"
-                    minor="${parts[1]}"
-                    ((minor--))
-                    docker_version="${parts[0]}.${minor}.${parts[2]}"
-                    echo "image_tag=${docker_version}" >> $GITHUB_OUTPUT
+                    ref=${{github.ref_name}}
+                    echo "image_tag=${ref#release/}" >> $GITHUB_OUTPUT
             -   name: 🧱 Image Construction and Publication
                 uses: docker/build-push-action@v5
                 with:


### PR DESCRIPTION
## 🗒️ Summary

Merge this to take care of an issue in publishing mismatched versions of Docker images to the Docker Hub. Now when pushing `release/1.2.3` to GitHub, you get Docker image tagged with `:1.2.3` in the Docker Hub.

## ⚙️ Test Data and/or Report

See the corresponding entries for `registry-moppers`, the "sandbox" version of this project, namely:

- The [GitHub Actions](https://github.com/nasa-pds-engineering-node/registry-moppers/actions/runs/8345132363/job/22839286911) stable workflow for `release/3.0.0`
- The [Docker Hub tags](https://hub.docker.com/r/nasapds/registry-moppers/tags) for `registry-moppers`, which has a corresponding `:3.0.0` tag around the same timeframe.

## ♻️ Related Issues

- #109 
