### PR TITLE
update client to support direct env var credentials for fargate compatibility

### DIFF
--- a/scratch/es-to-aoss-migration/dump-aoss-lidvids.py
+++ b/scratch/es-to-aoss-migration/dump-aoss-lidvids.py
@@ -3,12 +3,12 @@ import os
 from opensearchpy import RequestsAWSV4SignerAuth, OpenSearch, RequestsHttpConnection
 
 from pds.registrysweepers.utils.db import query_registry_db_with_search_after
-from pds.registrysweepers.utils.db.client import get_aws_credentials_from_ssm
+from pds.registrysweepers.utils.db.client import get_aws_credentials_from_ec2_metadata_service
 
 iam_role_name = 'temp-mcp-ec2-opensearch-role'
 aoss_host = 'b3rqys09xmx9i19yn64i.us-west-2.aoss.amazonaws.com'
 
-credentials = get_aws_credentials_from_ssm(iam_role_name)
+credentials = get_aws_credentials_from_ec2_metadata_service(iam_role_name)
 
 auth = RequestsAWSV4SignerAuth(credentials, 'us-west-2', 'aoss')
 

--- a/scratch/es-to-aoss-migration/upload-missing-content.py
+++ b/scratch/es-to-aoss-migration/upload-missing-content.py
@@ -3,12 +3,12 @@ import os
 from opensearchpy import RequestsAWSV4SignerAuth, OpenSearch, RequestsHttpConnection
 
 from pds.registrysweepers.utils.db import _write_bulk_updates_chunk
-from pds.registrysweepers.utils.db.client import get_aws_credentials_from_ssm
+from pds.registrysweepers.utils.db.client import get_aws_credentials_from_ec2_metadata_service
 
 iam_role_name = 'temp-mcp-ec2-opensearch-role'
 aoss_host = 'b3rqys09xmx9i19yn64i.us-west-2.aoss.amazonaws.com'
 
-credentials = get_aws_credentials_from_ssm(iam_role_name)
+credentials = get_aws_credentials_from_ec2_metadata_service(iam_role_name)
 
 auth = RequestsAWSV4SignerAuth(credentials, 'us-west-2', 'aoss')
 


### PR DESCRIPTION
## 🗒️ Summary
This is an attempt to add Fargate compatibility to sweepers' IAM auth.  Fargate doesn't have an equivalent service to the EC2 metadata service.  I've seen mention that it injects credentials directly using the standard environment variables, but I've been unable to find mention of this in AWS documentation.

Given the stakes and the desire to ensure that everything is 1:1 with the deployment setup, the plan is to merge, test, and revert this PR if unsuccessful.