### PR TITLE
Implement reindexer sweeper

### DIFF
--- a/docker/sweepers_driver.py
+++ b/docker/sweepers_driver.py
@@ -64,6 +64,7 @@ from datetime import datetime
 from typing import Callable
 
 from pds.registrysweepers import provenance, ancestry, repairkit, legacy_registry_sync
+from pds.registrysweepers.reindexer import main as reindexer
 from pds.registrysweepers.utils import configure_logging, parse_log_level
 from pds.registrysweepers.utils.db.client import get_opensearch_client_from_environment
 from pds.registrysweepers.utils.misc import get_human_readable_elapsed_since
@@ -107,7 +108,8 @@ args = parser.parse_args()
 sweepers = [
     repairkit.run,
     provenance.run,
-    ancestry.run
+    ancestry.run,
+    reindexer.run
 ]
 
 for option, sweeper in optional_sweepers.items():

--- a/docker/sweepers_driver.py
+++ b/docker/sweepers_driver.py
@@ -86,7 +86,8 @@ def run_factory(sweeper_f: Callable) -> Callable:
     return functools.partial(
         sweeper_f,
         client=get_opensearch_client_from_environment(verify_certs=True if not dev_mode else False),
-        log_filepath='registry-sweepers.log',
+        # enable for development if required - not necessary in production
+        # log_filepath='registry-sweepers.log',
         log_level=log_level
     )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     botocore~=1.34.91
     botocore-stubs~=1.34.94
     requests-aws4auth~=1.2.3
+    python-dateutil~=2.9.0
 
 # Change this to False if you use things like __file__ or __path__—which you
 # shouldn't use anyway, because that's what ``pkg_resources`` is for 🙂

--- a/src/pds/registrysweepers/ancestry/generation.py
+++ b/src/pds/registrysweepers/ancestry/generation.py
@@ -187,7 +187,7 @@ def generate_nonaggregate_and_collection_records_iteratively(
 
     for lid, collections_records_for_lid in collection_records_by_lid.items():
         if all([record.skip_write for record in collections_records_for_lid]):
-            log.info(f"Skipping updates for up-to-date collection family: {str(lid)}")
+            log.debug(f"Skipping updates for up-to-date collection family: {str(lid)}")
             continue
         else:
             log.info(

--- a/src/pds/registrysweepers/reindexer/constants.py
+++ b/src/pds/registrysweepers/reindexer/constants.py
@@ -1,1 +1,1 @@
-REINDEXER_FLAG_METADATA_KEY = "ops:Provenance/ops:requires_reindex"
+REINDEXER_FLAG_METADATA_KEY = "ops:Provenance/ops:reindexed_at"

--- a/src/pds/registrysweepers/reindexer/constants.py
+++ b/src/pds/registrysweepers/reindexer/constants.py
@@ -1,0 +1,1 @@
+REINDEXER_FLAG_METADATA_KEY = "ops:Provenance/ops:requires_reindex"

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -82,39 +82,33 @@ def accumulate_missing_mappings(
     @param docs: an iterable collection of product documents
     """
 
-    # TODO: map special-case property names onto their types, and incorporate them into the type resolution
-    #  NoneType indicates that the property is to be excluded
-    #  Anything with prefix 'ops:Provenance' should be excluded, as these properties are the responsibility of their
+    # Static mappings for fields not defined in the data dictionaries
+    # NoneType indicates that the property is to be excluded.
+    # Anything with prefix 'ops:Provenance' is excluded, as these properties are the responsibility of their
     #  respective sweepers.
     special_case_property_types_by_name = {
         '@timestamp': None,
         '@version': None,
         '_package_id': None,
         'description': 'text',
-        # 'lid':,
-        # 'lidvid',
+        'lid': 'keyword',
+        'lidvid': 'keyword',
         'ops:Harvest_Info/ops:harvest_date_time': 'date',
         'ops:Label_File_Info/ops:json_blob': None,
-        # 'ops:Provenance/ops:parent_bundle_identifier',
-        # 'ops:Provenance/ops:parent_collection_identifier',
-        # 'ops:Provenance/ops:registry_sweepers_ancestry_version',
-        # 'ops:Provenance/ops:registry_sweepers_provenance_version',
-        # 'ops:Provenance/ops:registry_sweepers_repairkit_version',
-        # 'ops:Provenance/ops:superseded_by',
-        # 'product_class',
-        # 'ref_lid_associate',
-        # 'ref_lid_collection',
-        # 'ref_lid_collection_secondary',
-        # 'ref_lid_data',
-        # 'ref_lid_document',
-        # 'ref_lid_facility',
-        # 'ref_lid_instrument',
-        # 'ref_lid_instrument_host',
-        # 'ref_lid_investigation',
-        # 'ref_lid_target',
-        # 'ref_lid_telescope',
+        'product_class': 'keyword',
+        'ref_lid_associate': 'keyword',
+        'ref_lid_collection': 'keyword',
+        'ref_lid_collection_secondary': 'keyword',
+        'ref_lid_data': 'keyword',
+        'ref_lid_document': 'keyword',
+        'ref_lid_facility': 'keyword',
+        'ref_lid_instrument': 'keyword',
+        'ref_lid_instrument_host': 'keyword',
+        'ref_lid_investigation': 'keyword',
+        'ref_lid_target': 'keyword',
+        'ref_lid_telescope': 'keyword',
         'title': 'text',
-        # 'vid'
+        # 'vid'  # TODO: need to determine what this should be, as keyword lexical(?) sorting will be a problem
     }
 
     missing_mapping_updates: Dict[str, str] = {}
@@ -289,7 +283,7 @@ def run(
     batch_size_limit = 100000
     sort_fields = ["ops:Harvest_Info/ops:harvest_date_time"]
     total_outstanding_doc_count = get_updated_hits_count()
-    
+
     with tqdm(
         total=total_outstanding_doc_count,
         desc=f"Reindexer sweeper progress",

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -141,7 +141,9 @@ def accumulate_missing_mappings(
                              and canonical_type is not None \
                              and current_mapping_type is not None
 
-            if not canonical_type_is_defined and property_name not in canonical_type_undefined_property_names:
+            if not canonical_type_is_defined \
+                    and property_name not in special_case_property_types_by_name \
+                    and property_name not in canonical_type_undefined_property_names:
                 log.warning(
                     f"Property {property_name} does not have an entry in the data dictionary index or hardcoded mappings - this may indicate a problem"
                 )

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -174,7 +174,9 @@ def accumulate_missing_mappings(
                 try:
                     problematic_harvest_versions.update(doc["_source"]["ops:Harvest_Info/ops:harvest_version"])
                 except KeyError as err:
-                    log.warning(f'Unable to extract harvest version from document {doc["_id"]}: {err}')
+                    # Noisy log temporarily disabled but may be re-enabled at jpadams' discretion
+                    # log.warning(f'Unable to extract harvest version from document {doc["_id"]}: {err}')
+                    pass
 
             if mapping_missing and property_name not in missing_mapping_updates:
                 if canonical_type_is_defined:

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -192,11 +192,8 @@ def accumulate_missing_mappings(
                     # be touched by the reindexer sweeper
                     log.warning(f'Property {property_name} is missing from the index mapping, but is a sweepers metadata attribute and will not be fixed here. Please run the full set of sweepers on this index')
                 else:
-                    default_type = "keyword"
-                    log.warning(
-                        f'Property {property_name} is missing from the index mappings and does not have an entry in the data dictionary index - defaulting to type "{default_type}"'
-                    )
-                    missing_mapping_updates[property_name] = default_type
+                    # if there is no canonical type and it is not a provenance metadata key, do nothing, per jpadams
+                    pass
 
     log.info(
         f"RESULT: Detected {format_hits_count(problem_docs_count)} docs with {len(missing_mapping_updates)} missing mappings and {len(bad_mapping_property_names)} mappings conflicting with the DD, out of a total of {format_hits_count(total_docs_count)} docs"

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -25,11 +25,18 @@ from pds.registrysweepers.utils.db.update import Update
 from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
 
 
+def do_local_test_init(client: OpenSearch):
+    doc_id = "urn:nasa:pds:insight_rad::2.1"
+    new_content = {"doc": {"edunntest": "someValue"}}
+    client.update("registry", doc_id, new_content)
+
+
 def run(
     client: OpenSearch,
     log_filepath: Union[str, None] = None,
     log_level: int = logging.INFO,
 ):
+    do_local_test_init(client)
     ensure_index_mapping(client, resolve_multitenant_index_name("registry"), REINDEXER_FLAG_METADATA_KEY, "date")
 
     print("complete")

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -216,7 +216,7 @@ def accumulate_missing_mappings(
 
     if len(canonical_type_undefined_property_names) > 0:
         log.info(
-            f"RESULT: Mappings were not found in the DD for the following properties, and a default type will be applied: {sorted(canonical_type_undefined_property_names)}"
+            f"RESULT: Mappings were not found in the DD or static types for the following properties: {sorted(canonical_type_undefined_property_names)}"
         )
 
     if len(bad_mapping_property_names) > 0:

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -69,7 +69,7 @@ def accumulate_missing_mappings(
     @param mapping_field_types_by_field_name: a mapping of document property names onto their types, derived from the existing index mappings
     @param docs: an iterable collection of product documents
     """
-    missing_mapping_updates = {}
+    missing_mapping_updates: Dict[str, str] = {}
 
     dd_not_defines_type_property_names = set()  # used to prevent duplicate WARN logs
     bad_mapping_property_names = set()  # used to log mappings requiring manual attention
@@ -133,7 +133,7 @@ def accumulate_missing_mappings(
                     log.info(
                         f'Property {property_name} will be updated to type "{canonical_type}" from data dictionary'
                     )
-                    missing_mapping_updates[property_name] = canonical_type
+                    missing_mapping_updates[property_name] = canonical_type  # type: ignore
                 else:
                     default_type = "keyword"
                     log.warning(
@@ -147,7 +147,7 @@ def accumulate_missing_mappings(
 
     if problem_docs_count > 0:
         log.warning(
-            f"Problems were detected with docs having harvest timestamps between {earliest_problem_doc_harvested_at.isoformat()} and {latest_problem_doc_harvested_at.isoformat()}"
+            f"Problems were detected with docs having harvest timestamps between {earliest_problem_doc_harvested_at.isoformat()} and {latest_problem_doc_harvested_at.isoformat()}"  # type: ignore
         )
         log.warning(f"Problems were detected with docs having harvest versions {sorted(problematic_harvest_versions)}")
 

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -293,7 +293,7 @@ def run(
             # significant redundant load
             # N.B. the returned hits count may fluctuate - this is due to delay in propagation between shards
             expected_remaining_hits = total_outstanding_doc_count - pbar.n
-            hits_stall_tolerance = math.ceil(0.05 * batch_size_limit)
+            hits_stall_tolerance = math.ceil(0.10 * batch_size_limit)
             stall_while_hits_exceed_count = expected_remaining_hits + hits_stall_tolerance
             while get_updated_hits_count() > stall_while_hits_exceed_count:
                 stall_period = timedelta(seconds=60)

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -290,11 +290,6 @@ def run(
     sort_fields = ["ops:Harvest_Info/ops:harvest_date_time"]
     total_outstanding_doc_count = get_updated_hits_count()
     
-    # continuing when n% of a batch is still pending in db will result in an accumulating disparity between the number
-    # of updates submitted and the number of distinct updates submitted.  This variable accumulates an upper bound for
-    # that error, which is necessary to prevent an infinite loop when it exceeds the n% threshold
-    accumulated_error_from_duplicate_updates = 0
-
     with tqdm(
         total=total_outstanding_doc_count,
         desc=f"Reindexer sweeper progress",

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -247,14 +247,18 @@ def generate_updates(
 
 def format_hits_count(count: int) -> str:
     """Format hits count in a more human-friendly manner for logs"""
-    if count < 10e4:
+    if count < 1e4:
         return str(count)
-    elif count < 10e6:
-        adjusted_count = count / 10e3
+    elif count < 1e5:
+        adjusted_count = count / 1e3
+        return '{:,.1f}K'.format(adjusted_count)
+    elif count < 1e6:
+        adjusted_count = count / 1e3
         return '{:,.0f}K'.format(adjusted_count)
     else:
-        adjusted_count = count / 10e6
+        adjusted_count = count / 1e6
         return '{:,.2f}M'.format(adjusted_count)
+
 
 def run(
     client: OpenSearch,

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -143,6 +143,7 @@ def accumulate_missing_mappings(
 
             if not canonical_type_is_defined \
                     and property_name not in special_case_property_types_by_name \
+                    and not property_name.startswith('ops:Provenance') \
                     and property_name not in canonical_type_undefined_property_names:
                 log.warning(
                     f"Property {property_name} does not have an entry in the data dictionary index or hardcoded mappings - this may indicate a problem"

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -234,12 +234,12 @@ def generate_updates(
         extant_mapping_keys = set(extant_mapping_keys)
         document_field_names = set(document["_source"].keys())
         document_fields_missing_from_mappings = document_field_names.difference(extant_mapping_keys)
-        if len(document_fields_missing_from_mappings) == 0:
-            yield Update(id=id, content={REINDEXER_FLAG_METADATA_KEY: timestamp.isoformat()})
-        else:
+        if len(document_fields_missing_from_mappings) > 0:
             logging.debug(
                 f"Missing mappings {document_fields_missing_from_mappings} detected when attempting to create Update for doc with id {id} - skipping"
             )
+
+        yield Update(id=id, content={REINDEXER_FLAG_METADATA_KEY: timestamp.isoformat()})
 
 
 def format_hits_count(count: int) -> str:

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -196,7 +196,7 @@ def run(
 
     updates = generate_updates(
         sweeper_start_timestamp,
-        query_registry_db_with_search_after(
+        query_registry_db_with_search_after_until_zero_hits(
             client, products_index_name, _source={}, query=get_docs_query(sweeper_start_timestamp)
         ),
     )

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -142,18 +142,30 @@ def accumulate_missing_mappings(
                     missing_mapping_updates[property_name] = default_type
 
     log.info(
-        f"Detected {problem_docs_count} docs with {len(missing_mapping_updates)} missing mappings and {len(bad_mapping_property_names)} mappings conflicting with the DD, out of a total of {total_docs_count} docs"
+        f"RESULT: Detected {problem_docs_count} docs with {len(missing_mapping_updates)} missing mappings and {len(bad_mapping_property_names)} mappings conflicting with the DD, out of a total of {total_docs_count} docs"
     )
 
     if problem_docs_count > 0:
         log.warning(
-            f"Problems were detected with docs having harvest timestamps between {earliest_problem_doc_harvested_at.isoformat()} and {latest_problem_doc_harvested_at.isoformat()}"  # type: ignore
+            f"RESULT: Problems were detected with docs having harvest timestamps between {earliest_problem_doc_harvested_at.isoformat()} and {latest_problem_doc_harvested_at.isoformat()}"  # type: ignore
         )
-        log.warning(f"Problems were detected with docs having harvest versions {sorted(problematic_harvest_versions)}")
+        log.warning(
+            f"RESULT: Problems were detected with docs having harvest versions {sorted(problematic_harvest_versions)}"
+        )
+
+    if len(missing_mapping_updates) > 0:
+        log.info(
+            f"RESULT: Mappings will be added for the following properties: {sorted(missing_mapping_updates.keys())}"
+        )
+
+    if len(dd_not_defines_type_property_names) > 0:
+        log.info(
+            f"RESULT: Mappings were not found in the DD for the following properties, and a default type will be applied: {sorted(dd_not_defines_type_property_names)}"
+        )
 
     if len(bad_mapping_property_names) > 0:
         log.error(
-            f"The following mappings have a type which does not match the type described by the data dictionary: {bad_mapping_property_names} - in-place update is not possible, data will need to be manually reindexed with manual updates (or that functionality must be added to this sweeper"
+            f"RESULT: The following mappings have a type which does not match the type described by the data dictionary: {bad_mapping_property_names} - in-place update is not possible, data will need to be manually reindexed with manual updates (or that functionality must be added to this sweeper"
         )
 
     return missing_mapping_updates

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -196,7 +196,7 @@ def accumulate_missing_mappings(
                     missing_mapping_updates[property_name] = default_type
 
     log.info(
-        f"RESULT: Detected {problem_docs_count} docs with {len(missing_mapping_updates)} missing mappings and {len(bad_mapping_property_names)} mappings conflicting with the DD, out of a total of {total_docs_count} docs"
+        f"RESULT: Detected {format_hits_count(problem_docs_count)} docs with {len(missing_mapping_updates)} missing mappings and {len(bad_mapping_property_names)} mappings conflicting with the DD, out of a total of {format_hits_count(total_docs_count)} docs"
     )
 
     if problem_docs_count > 0:
@@ -242,6 +242,17 @@ def generate_updates(
             )
 
 
+def format_hits_count(count: int) -> str:
+    """Format hits count in a more human-friendly manner for logs"""
+    if count < 10e4:
+        return str(count)
+    elif count < 10e6:
+        adjusted_count = count / 10e3
+        return '{:,.0f}K'.format(adjusted_count)
+    else:
+        adjusted_count = count / 10e6
+        return '{:,.2f}M'.format(adjusted_count)
+
 def run(
     client: OpenSearch,
     log_filepath: Union[str, None] = None,
@@ -283,7 +294,7 @@ def run(
             stall_while_hits_exceed_count = expected_remaining_hits + hits_stall_tolerance
             while get_updated_hits_count() > stall_while_hits_exceed_count:
                 stall_period = timedelta(seconds=60)
-                logging.info(f'Many updates pending, waiting {int(stall_period.total_seconds())}s until hits count falls below {stall_while_hits_exceed_count} (expected {expected_remaining_hits}, got {get_updated_hits_count()})')
+                logging.info(f'Many updates pending, waiting {int(stall_period.total_seconds())}s until hits count falls below {format_hits_count(stall_while_hits_exceed_count)} (expected {format_hits_count(expected_remaining_hits)}, got {format_hits_count(get_updated_hits_count())})')
                 sleep(stall_period.total_seconds())
 
             mapping_field_types_by_field_name = get_mapping_field_types_by_field_name(client, products_index_name)

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -30,6 +30,12 @@ def get_docs_query(filter_to_harvested_before: datetime):
     """
     Return a query to get all docs which haven't been reindexed by this sweeper and which haven't been harvested
     since this sweeper process instance started running
+
+    i.e.
+    - Query all documents
+    - Exclude anything which has already been processed, to avoid redundant reprocessing
+    - Exclude anything which was harvested in the middle of this sweeper running, since this can cause erroneous results
+      due to inconsistency in the document set across query calls which are expected to be identical.
     """
     # TODO: Remove this once query_registry_db_with_search_after is modified to remove mutation side-effects
     return {

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -121,6 +121,7 @@ def accumulate_missing_mappings(
 
     canonical_type_undefined_property_names = set()  # used to prevent duplicate WARN logs
     bad_mapping_property_names = set()  # used to log mappings requiring manual attention
+    sweepers_missing_property_names = set()
 
     earliest_problem_doc_harvested_at = None
     latest_problem_doc_harvested_at = None
@@ -191,7 +192,9 @@ def accumulate_missing_mappings(
                 elif property_name.startswith('ops:Provenance'):  # TODO: extract this to a constant, used by all metadata key definitions
                     # mappings for registry-sweepers are the responsibility of their respective sweepers and should not
                     # be touched by the reindexer sweeper
-                    log.warning(f'Property {property_name} is missing from the index mapping, but is a sweepers metadata attribute and will not be fixed here. Please run the full set of sweepers on this index')
+                    if property_name not in sweepers_missing_property_names:
+                        log.warning(f'Property {property_name} is missing from the index mapping, but is a sweepers metadata attribute and will not be fixed here. Please run the full set of sweepers on this index')
+                        sweepers_missing_property_names.add(property_name)
                 else:
                     # if there is no canonical type and it is not a provenance metadata key, do nothing, per jpadams
                     pass

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -1,0 +1,60 @@
+import json
+import logging
+import os
+import tempfile
+from itertools import chain
+from typing import Callable
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import TextIO
+from typing import Tuple
+from typing import Union
+
+from opensearchpy import OpenSearch
+from pds.registrysweepers.reindexer.constants import REINDEXER_FLAG_METADATA_KEY
+from pds.registrysweepers.utils import configure_logging
+from pds.registrysweepers.utils import parse_args
+from pds.registrysweepers.utils.db import write_updated_docs
+from pds.registrysweepers.utils.db.client import get_userpass_opensearch_client
+from pds.registrysweepers.utils.db.indexing import ensure_index_mapping
+from pds.registrysweepers.utils.db.multitenancy import resolve_multitenant_index_name
+from pds.registrysweepers.utils.db.update import Update
+from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
+
+
+def run(
+    client: OpenSearch,
+    log_filepath: Union[str, None] = None,
+    log_level: int = logging.INFO,
+):
+    print("complete")
+    pass
+
+
+if __name__ == "__main__":
+    cli_description = f"""
+    Tests untested documents in registry index to ensure that all properties are present in the index mapping (i.e. that
+    they are searchable).
+
+    When a document is tested, metadata attribute {REINDEXER_FLAG_METADATA_KEY} is given a value of true if any fields
+    are missing from the index mapping, or false if otherwise.  The presence of attribute {REINDEXER_FLAG_METADATA_KEY}
+    indicates that the document has been tested and may be skipped in future.
+
+    Once complete, the sweeper will create a temporary index, reindex all documents having
+    {REINDEXER_FLAG_METADATA_KEY}=true to the temporary index, delete those documents then reindex them
+
+    """
+
+    args = parse_args(description=cli_description)
+    client = get_userpass_opensearch_client(
+        endpoint_url=args.base_URL, username=args.username, password=args.password, verify_certs=not args.insecure
+    )
+
+    run(
+        client=client,
+        log_level=args.log_level,
+        log_filepath=args.log_file,
+    )

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -282,8 +282,8 @@ def run(
             hits_stall_tolerance = math.ceil(0.05 * batch_size_limit)
             stall_while_hits_exceed_count = expected_remaining_hits + hits_stall_tolerance
             while get_updated_hits_count() > stall_while_hits_exceed_count:
-                stall_period = timedelta(seconds=10)
-                logging.info(f'Many updates pending, waiting {stall_period.total_seconds()}s until hits count falls below {stall_while_hits_exceed_count} (expected {expected_remaining_hits}, got {get_updated_hits_count()})')
+                stall_period = timedelta(seconds=60)
+                logging.info(f'Many updates pending, waiting {int(stall_period.total_seconds())}s until hits count falls below {stall_while_hits_exceed_count} (expected {expected_remaining_hits}, got {get_updated_hits_count()})')
                 sleep(stall_period.total_seconds())
 
             mapping_field_types_by_field_name = get_mapping_field_types_by_field_name(client, products_index_name)

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -30,6 +30,8 @@ def run(
     log_filepath: Union[str, None] = None,
     log_level: int = logging.INFO,
 ):
+    ensure_index_mapping(client, resolve_multitenant_index_name("registry"), REINDEXER_FLAG_METADATA_KEY, "date")
+
     print("complete")
     pass
 
@@ -37,14 +39,14 @@ def run(
 if __name__ == "__main__":
     cli_description = f"""
     Tests untested documents in registry index to ensure that all properties are present in the index mapping (i.e. that
-    they are searchable).
+    they are searchable).  Mapping types are derived from <<<to be determined>>>
 
-    When a document is tested, metadata attribute {REINDEXER_FLAG_METADATA_KEY} is given a value of true if any fields
-    are missing from the index mapping, or false if otherwise.  The presence of attribute {REINDEXER_FLAG_METADATA_KEY}
-    indicates that the document has been tested and may be skipped in future.
+    When a document is tested, metadata attribute {REINDEXER_FLAG_METADATA_KEY} is given a value equal to the timestamp
+    at sweeper runtime. The presence of attribute {REINDEXER_FLAG_METADATA_KEY} indicates that the document has been
+    tested and may be skipped in future.
 
-    Once complete, the sweeper will create a temporary index, reindex all documents having
-    {REINDEXER_FLAG_METADATA_KEY}=true to the temporary index, delete those documents then reindex them
+    Writing a new value to this attribute triggers a re-index of the entire document, ensuring that the document is
+    fully-searchable.
 
     """
 

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -19,12 +19,6 @@ from pds.registrysweepers.utils.db.update import Update
 log = logging.getLogger(__name__)
 
 
-def do_local_test_init(client: OpenSearch):
-    doc_id = "urn:nasa:pds:insight_rad::2.1"
-    new_content = {"doc": {"edunnKeywordTest": "someKeyword", "edunnDatetimeTest": "2018-02-01T00:00:00Z"}}
-    client.update("registry", doc_id, new_content)
-
-
 def get_docs_query(filter_to_harvested_before: datetime):
     """
     Return a query to get all docs which haven't been reindexed by this sweeper and which haven't been harvested
@@ -178,7 +172,6 @@ def run(
 ):
     configure_logging(filepath=log_filepath, log_level=log_level)
 
-    do_local_test_init(client)
     sweeper_start_timestamp = datetime.now()
     products_index_name = resolve_multitenant_index_name("registry")
     ensure_index_mapping(client, products_index_name, REINDEXER_FLAG_METADATA_KEY, "date")

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -1,10 +1,8 @@
 import logging
 from datetime import datetime
 from datetime import timezone
-from typing import Any
 from typing import Dict
 from typing import Iterable
-from typing import Set
 from typing import Union
 
 from opensearchpy import OpenSearch
@@ -30,7 +28,7 @@ def do_local_test_init(client: OpenSearch):
 def get_docs_query(filter_to_harvested_before: datetime):
     """
     Return a query to get all docs which haven't been reindexed by this sweeper and which haven't been harvested
-    during this sweeper run
+    since this sweeper process instance started running
     """
     # TODO: Remove this once query_registry_db_with_search_after is modified to remove mutation side-effects
     return {

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -219,7 +219,7 @@ def run(
     # within generate_updates() to ensure that the second stage (update generation) hasn't picked up any products which
     # weren't processed in the first stage (missing mapping accumulation)
     batch_size_limit = 100000
-    sort_fields = ["ops:Harvest_Info.ops:harvest_date_time"]
+    sort_fields = ["ops:Harvest_Info/ops:harvest_date_time"]
     with tqdm(
         total=get_query_hits_count(client, products_index_name, get_docs_query(sweeper_start_timestamp)),
         desc=f"Reindexer sweeper progress",

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -333,6 +333,9 @@ def _write_bulk_updates_chunk(client: OpenSearch, index_name: str, bulk_updates:
     if response_content.get("errors"):
         warn_types = {"document_missing_exception"}  # these types represent bad data, not bad sweepers behaviour
         items_with_problems = [item for item in response_content["items"] if "error" in item["update"]]
+        if any(item['update']['status'] == 429 and item['update']['error']['type'] == 'circuit_breaking_exception' for item in items_with_problems):
+            raise RuntimeWarning(f'Bulk updates response includes item with status HTTP429, circuit_breaking_exception/throttled - chunk will need to be resubmitted')
+
 
         def get_ids_list_str(ids: List[str]) -> str:
             max_display_ids = 50

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -171,8 +171,8 @@ def query_registry_db_with_search_after(
             #           https://discuss.elastic.co/t/problem-with-colon-in-fieldname-where-can-i-find-naming-guidelines/5437/4
             #           https://discuss.elastic.co/t/revisiting-colons-in-field-names/25005
             # TODO: investigate and open ticket with opensearch-py if confirmed
-            special_characters = {'/', ':'}
-            query['sort'] = [f for f in sort_fields if any(c in f for c in special_characters)]
+            special_characters = {"/", ":"}
+            query["sort"] = [f for f in sort_fields if any(c in f for c in special_characters)]
 
             if search_after_values is not None:
                 query["search_after"] = search_after_values
@@ -228,8 +228,9 @@ def query_registry_db_with_search_after(
                         if len(value) == 1:
                             search_after_values[idx] = value[0]
                         else:
-                            raise ValueError(f'Failed to flatten array-like search-after value {value} into single element')
-
+                            raise ValueError(
+                                f"Failed to flatten array-like search-after value {value} into single element"
+                            )
 
             # This is a temporary, ad-hoc guard against empty/erroneous responses which do not return non-200 status codes.
             # Previously, this has cause infinite loops in production due to served_hits sticking and never reaching the
@@ -341,9 +342,13 @@ def _write_bulk_updates_chunk(client: OpenSearch, index_name: str, bulk_updates:
     if response_content.get("errors"):
         warn_types = {"document_missing_exception"}  # these types represent bad data, not bad sweepers behaviour
         items_with_problems = [item for item in response_content["items"] if "error" in item["update"]]
-        if any(item['update']['status'] == 429 and item['update']['error']['type'] == 'circuit_breaking_exception' for item in items_with_problems):
-            raise RuntimeWarning(f'Bulk updates response includes item with status HTTP429, circuit_breaking_exception/throttled - chunk will need to be resubmitted')
-
+        if any(
+            item["update"]["status"] == 429 and item["update"]["error"]["type"] == "circuit_breaking_exception"
+            for item in items_with_problems
+        ):
+            raise RuntimeWarning(
+                "Bulk updates response includes item with status HTTP429, circuit_breaking_exception/throttled - chunk will need to be resubmitted"
+            )
 
         def get_ids_list_str(ids: List[str]) -> str:
             max_display_ids = 50

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -324,7 +324,7 @@ def update_as_statements(update: Update) -> Iterable[str]:
 
 
 @retry(tries=6, delay=15, backoff=2, logger=log)
-def _write_bulk_updates_chunk(client: OpenSearch, index_name: str, bulk_updates: Iterable[str]):
+def _write_bulk_updates_chunk(client: OpenSearch, index_name: str, bulk_updates: List[str]):
     bulk_data = "\n".join(bulk_updates) + "\n"
 
     request_timeout = 180

--- a/src/pds/registrysweepers/utils/db/indexing.py
+++ b/src/pds/registrysweepers/utils/db/indexing.py
@@ -2,5 +2,9 @@ from opensearchpy import OpenSearch
 
 
 def ensure_index_mapping(client: OpenSearch, index_name: str, property_name: str, property_type: str):
-    """Provides an easy-to-use wrapper for ensuring the presence of a given property name/type in a given index"""
+    """
+    Provides an easy-to-use wrapper for ensuring the presence of a given property name/type in a given index.
+    N.B. This cannot change the type of a mapping, as modification/deletion is impossible in ES/OS.  If the mapping
+    already exists, matching type or not, the function will gracefully fail and log an HTTP400 error.
+    """
     client.indices.put_mapping(index=index_name, body={"properties": {property_name: {"type": property_type}}})

--- a/src/pds/registrysweepers/utils/db/multitenancy.py
+++ b/src/pds/registrysweepers/utils/db/multitenancy.py
@@ -2,7 +2,7 @@ import os
 
 
 def resolve_multitenant_index_name(index_type: str):
-    supported_index_types = {"registry", "registry-refs"}
+    supported_index_types = {"registry", "registry-refs", "registry-dd"}
     node_id = os.environ.get("MULTITENANCY_NODE_ID", "").strip(" ")
 
     if node_id == "":


### PR DESCRIPTION
## 🗒️ Summary
Implements a sweeper with the following behaviour:
- Sweeps all documents in the `registry` index which haven't been swept yet by this sweeper and were not been harvested since the time the sweeper began execution (to ensure consistency of queries)
- Generates a list of fields which are present in the product documents but not present in the index mapping, or which have mappings contradicting the info available in the `registry-dd` index
- For missing mappings, resolves a type from the `registry-dd` index if available, else defaults to `keyword`
- For conflicting mappings, logs an error stating that there is a mismatch which is not resolvable in-place and which requires a manual update/migration of the documents to a new index. (Modification/deletion of mapping entries is technically impossible in ES/OS).  This functionality could be built into the sweeper if desired, but it seems like an edge case so it is omitted for now.
- Writes updates to `_mappings` for all missing properties
- Writes a consistent (per-sweeper-run) timestamp to metadata field `ops:Provenance/ops:reindexed_at`, which is used to identify when documents were checked/fixed, and which triggers a whole-document reindex operation, ensuring that any just-added mappings become searchable for that document.
- Logs a summary of the update operations performed

@jordanpadams @tloubrieu-jpl could you please review these requirements to ensure that they accurately reflect the desired behaviour?

## ⚙️ Test Data and/or Report
Manually tested:
 - logged counts are correct
 - missing mappings are added, iff they are enumerated in the DD or static (hardcoded) type mappings
 - conflicting mappings are logged
 - types of missing mappings change according to the resolved typename
 - metadata updates are written to db
 - metadata updates are sufficient to trigger re-index, causing previously-unsearchable properties to become searchable.
 - presence of metadata attribute excludes document from document set on subsequent runs
 - harvest timestamp after execution start excludes document from document set
 
@jordanpadams @tloubrieu-jpl having tested locally on the I&T db, would you like me to run the sweeper against one/some of the MCP indices, after the code has been reviewed?

## ♻️ Related Issues
resolves #148 once run/deployed
related to https://github.com/NASA-PDS/registry/issues/230
