### PR TITLE
Make legacy synchronization sweeper work on multitenant opensearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,7 @@ DEV_MODE=1  // disables host verification
 PYDEVD_USE_CYTHON=NO // disables Cython speedup extension
 ```
 
-With `--legacy-sync` option, you also need the list of the cross-cluster-search node configured to access all the node's OpensSearch domains:
-
-```
-CCS_CONN=naif-prod-ccs,rms-prod,sbnumd-prod-ccs,geo-prod-ccs,atm-prod-ccs,sbnpsi-prod-ccs,ppi-prod-ccs,img-prod-ccs
-```
+With `--legacy-sync` option, the "registry" alias mapping all the discipline nodes indexes is required.
 
 Use the connection aliases found in the 'Connections' tab of the Engineering Node OpenSearch Domain on AWS.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,8 +14,8 @@ Requires a running deployment of registry
 To build and run  (assuming registry local-dev defaults for host/credentials)
 
     cd path/to/registry-sweepers/
-    docker image build --tag registry-sweepers --file ./docker/Dockerfile .
-    docker run --env PROV_ENDPOINT='https://localhost:9200/' --env PROV_CREDENTIALS='{"admin": "admin"}' registry-sweepers
+    docker image build --tag nasapds/registry-sweepers --file ./docker/Dockerfile .
+    docker run --env PROV_ENDPOINT='https://localhost:9200/' --env PROV_CREDENTIALS='{"admin": "admin"}' nasa-pds/registry-sweepers
 
 ### Release of new versions
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,7 @@ To build and run  (assuming registry local-dev defaults for host/credentials)
 
     cd path/to/registry-sweepers/
     docker image build --tag nasapds/registry-sweepers --file ./docker/Dockerfile .
-    docker run --env PROV_ENDPOINT='https://localhost:9200/' --env PROV_CREDENTIALS='{"admin": "admin"}' nasa-pds/registry-sweepers
+    docker run --env PROV_ENDPOINT='https://localhost:9200/' --env PROV_CREDENTIALS='{"admin": "admin"}' nasapds/registry-sweepers
 
 ### Release of new versions
 

--- a/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
@@ -65,5 +65,5 @@ def run(
         if not ok:
             log.error(item)
 
-        if dev_mode:
-            break
+        # if dev_mode:
+        #    break

--- a/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
@@ -65,5 +65,5 @@ def run(
         if not ok:
             log.error(item)
 
-        # if dev_mode:
-        #    break
+        if dev_mode:
+            break

--- a/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
@@ -56,14 +56,13 @@ def run(
         product_classes=["Product_Context", "Product_Collection", "Product_Bundle"], es_conn=client
     )
 
-    tries = 0
     es_actions = SolrOsWrapperIter(solr_itr, OS_INDEX, found_ids=prod_ids)
     dev_mode = is_dev_mode()
-    for ok, item in opensearchpy.helpers.streaming_bulk(
+    for operation_successful, operation_info in opensearchpy.helpers.streaming_bulk(
         client, es_actions, chunk_size=50, max_chunk_bytes=50000000, max_retries=5, initial_backoff=10
     ):
-        if not ok:
-            log.error(item)
+        if not operation_successful:
+            log.error(operation_info)
 
         if dev_mode:
             break

--- a/src/pds/registrysweepers/legacy_registry_sync/opensearch_loaded_product.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/opensearch_loaded_product.py
@@ -7,24 +7,6 @@ import opensearchpy  # type: ignore
 CCS_CONN = "CCS_CONN"
 
 
-def get_cross_cluster_indices():
-    """
-
-    Get the aliases for the Cross Cluster Search from an environment variable
-    @return: the aliases in a list including the main index.
-    """
-
-    indices = ["registry"]
-
-    if CCS_CONN in os.environ:
-        ccs_conn = os.environ[CCS_CONN]
-        if ccs_conn:
-            clusters = os.environ[CCS_CONN].split(",")
-            indices.extend([f"{c}:registry" for c in clusters])
-
-    return indices
-
-
 def get_already_loaded_lidvids(product_classes=None, es_conn=None):
     """
     Get the lidvids of the PDS4 products already loaded in the (new) registry.
@@ -45,5 +27,5 @@ def get_already_loaded_lidvids(product_classes=None, es_conn=None):
             dict(match_phrase={prod_class_prop: prod_class}) for prod_class in product_classes
         ]
 
-    prod_id_resp = opensearchpy.helpers.scan(es_conn, index=get_cross_cluster_indices(), query=query, scroll="3m")
+    prod_id_resp = opensearchpy.helpers.scan(es_conn, index=["registry"], query=query, scroll="3m")
     return [p["_id"] for p in prod_id_resp]

--- a/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
@@ -30,10 +30,8 @@ def pds4_id_field_fun(doc):
     @param doc: document from the legacy registry
     @return: lidvid
     """
-    if "version_id" in doc:
-        return doc["identifier"] + "::" + doc["version_id"][-1]
-    elif "identifier" in doc:
-        return doc["identifier"]
+    if "lidvid" in doc:
+        return doc["lidvid"]
     else:
         raise MissingIdentifierError()
 


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This was broken and unused since we migrated the registry to opensearch serverless. This has been fixed and leverages the "registry" index alias.
This also adapts to updates that occured in the legacy registry (SOLR) while we stopped using this sweeper.

## ⚙️ Test Data and/or Report
Tested with the registry docker compose set up.


## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

https://github.com/NASA-PDS/registry/issues/370
