### PR TITLE
Main provenance version hotfix

### DIFF
--- a/src/pds/registrysweepers/provenance/__init__.py
+++ b/src/pds/registrysweepers/provenance/__init__.py
@@ -54,6 +54,7 @@ from typing import Union
 from opensearchpy import OpenSearch
 from pds.registrysweepers.provenance.constants import METADATA_SUCCESSOR_KEY
 from pds.registrysweepers.provenance.provenancerecord import ProvenanceRecord
+from pds.registrysweepers.provenance.versioning import SWEEPERS_BROKEN_PROVENANCE_VERSION_METADATA_KEY
 from pds.registrysweepers.provenance.versioning import SWEEPERS_PROVENANCE_VERSION
 from pds.registrysweepers.provenance.versioning import SWEEPERS_PROVENANCE_VERSION_METADATA_KEY
 from pds.registrysweepers.utils import configure_logging
@@ -282,6 +283,7 @@ def generate_updates(records: Iterable[ProvenanceRecord]) -> Iterable[Update]:
         update_content = {
             METADATA_SUCCESSOR_KEY: str(record.successor) if record.successor else None,
             SWEEPERS_PROVENANCE_VERSION_METADATA_KEY: SWEEPERS_PROVENANCE_VERSION,
+            SWEEPERS_BROKEN_PROVENANCE_VERSION_METADATA_KEY: None,  # see comment in versioning.py for context - edunn
         }
 
         if record.skip_write:

--- a/src/pds/registrysweepers/provenance/versioning.py
+++ b/src/pds/registrysweepers/provenance/versioning.py
@@ -4,4 +4,8 @@
 from pds.registrysweepers.utils.misc import get_sweeper_version_metadata_key
 
 SWEEPERS_PROVENANCE_VERSION = 2
-SWEEPERS_PROVENANCE_VERSION_METADATA_KEY = get_sweeper_version_metadata_key("provenance")
+# At some point, provenance version metadata attributes were indexed differently as integer/keyword (should be integer)
+# As a hotfix, a new key is being used - eventually it will be necessary to re-index all nodes under corrected mappings,
+# as mappings may not be changed - edunn 20250730
+SWEEPERS_PROVENANCE_VERSION_METADATA_KEY = get_sweeper_version_metadata_key("provenance_hotfixed")
+SWEEPERS_BROKEN_PROVENANCE_VERSION_METADATA_KEY = get_sweeper_version_metadata_key("provenance")

--- a/tests/pds/registrysweepers/provenance/test_provenance.py
+++ b/tests/pds/registrysweepers/provenance/test_provenance.py
@@ -6,7 +6,10 @@ import unittest
 from pds.registrysweepers import provenance
 from pds.registrysweepers.provenance import ProvenanceRecord
 from pds.registrysweepers.provenance import SWEEPERS_PROVENANCE_VERSION
+from pds.registrysweepers.provenance import SWEEPERS_PROVENANCE_VERSION_METADATA_KEY
 from pds.registrysweepers.utils.db import Update
+
+from build.lib.pds.registrysweepers.provenance.versioning import SWEEPERS_BROKEN_PROVENANCE_VERSION_METADATA_KEY
 
 
 class ProvenanceBasicFunctionalTestCase(unittest.TestCase):
@@ -52,7 +55,8 @@ class ProvenanceBasicFunctionalTestCase(unittest.TestCase):
                 id=k,
                 content={
                     "ops:Provenance/ops:superseded_by": v,
-                    "ops:Provenance/ops:registry_sweepers_provenance_version": SWEEPERS_PROVENANCE_VERSION,
+                    SWEEPERS_PROVENANCE_VERSION_METADATA_KEY: SWEEPERS_PROVENANCE_VERSION,
+                    SWEEPERS_BROKEN_PROVENANCE_VERSION_METADATA_KEY: None,
                 },
             )
             for k, v in expected_provenance.items()


### PR DESCRIPTION
## 🗒️ Summary

Some nodes erroneously type the provenance software version metadata value as `keyword` rather than `integer`.

Since the addition of a mapping integrity check in #169 (?) this has caused a fatal error during the attempt to ensure it is mapped as `integer`.

This PR hotfixes the issue by replacing the in-use key `ops:Provenance/ops:registry_sweepers_provenance_version` with a new one `ops:Provenance/ops:registry_sweepers_provenance_hotfixed_version`, allowing all nodes to be updated without a complete migration to a new index.

Brief summary of changes if not sufficiently described by commit messages.

## ⚙️ Test Data and/or Report
Tests pass

## ♻️ Related Issues

May address #171, but need to confirm after deployment
