### PR TITLE
Log length limiter hotfix

### DIFF
--- a/src/pds/registrysweepers/ancestry/__init__.py
+++ b/src/pds/registrysweepers/ancestry/__init__.py
@@ -35,9 +35,8 @@ from pds.registrysweepers.utils.db.client import get_userpass_opensearch_client
 from pds.registrysweepers.utils.db.indexing import ensure_index_mapping
 from pds.registrysweepers.utils.db.multitenancy import resolve_multitenant_index_name
 from pds.registrysweepers.utils.db.update import Update
-from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
-
 from pds.registrysweepers.utils.misc import limit_log_length
+from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
 
 log = logging.getLogger(__name__)
 
@@ -125,9 +124,11 @@ def run(
             orphaned_doc_count = orphan_counter_f(client, index_name)
 
         if orphaned_doc_count > 0:
-            log.warning(limit_log_length(
-                f'Detected {orphaned_doc_count} orphaned documents in index "{index_name} - please inform developers": {orphaned_doc_ids_str}'
-            ))
+            log.warning(
+                limit_log_length(
+                    f'Detected {orphaned_doc_count} orphaned documents in index "{index_name} - please inform developers": {orphaned_doc_ids_str}'
+                )
+            )
 
     log.info(limit_log_length("Ancestry sweeper processing complete!"))
 
@@ -173,10 +174,12 @@ def generate_updates(
                 bulk_updates_sink.append((update.id, update.content))
 
             if update.id in updated_doc_ids:
-                log.debug(limit_log_length(
-                    f"Multiple updates detected for doc_id {update.id} - deferring subsequent parts"
-                    " - storing in {deferred_updates_file.name}"
-                ))
+                log.debug(
+                    limit_log_length(
+                        f"Multiple updates detected for doc_id {update.id} - deferring subsequent parts"
+                        " - storing in {deferred_updates_file.name}"
+                    )
+                )
                 deferred_records_file.write(json.dumps(record.to_dict(sort_lists=False)) + "\n")
                 deferred_records_file.flush()
                 continue
@@ -214,7 +217,9 @@ def generate_deferred_updates(
             update = update_from_record(record)
             yield update
         except (KeyError, ValueError) as err:
-            log.error(limit_log_length(f'Failed to parse valid AncestryRecord from document with id "{doc["_id"]}: {err}"'))
+            log.error(
+                limit_log_length(f'Failed to parse valid AncestryRecord from document with id "{doc["_id"]}: {err}"')
+            )
 
         # TODO: Check that ancestry version is equal to current, throw if not.
 

--- a/src/pds/registrysweepers/ancestry/__init__.py
+++ b/src/pds/registrysweepers/ancestry/__init__.py
@@ -37,7 +37,7 @@ from pds.registrysweepers.utils.db.multitenancy import resolve_multitenant_index
 from pds.registrysweepers.utils.db.update import Update
 from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
 
-from src.pds.registrysweepers.utils.misc import limit_log_length
+from pds.registrysweepers.utils.misc import limit_log_length
 
 log = logging.getLogger(__name__)
 

--- a/src/pds/registrysweepers/ancestry/generation.py
+++ b/src/pds/registrysweepers/ancestry/generation.py
@@ -40,7 +40,7 @@ from pds.registrysweepers.utils.productidentifiers.factory import PdsProductIden
 from pds.registrysweepers.utils.productidentifiers.pdslid import PdsLid
 from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
 
-from src.pds.registrysweepers.utils.misc import limit_log_length
+from pds.registrysweepers.utils.misc import limit_log_length
 
 log = logging.getLogger(__name__)
 

--- a/src/pds/registrysweepers/ancestry/generation.py
+++ b/src/pds/registrysweepers/ancestry/generation.py
@@ -40,6 +40,8 @@ from pds.registrysweepers.utils.productidentifiers.factory import PdsProductIden
 from pds.registrysweepers.utils.productidentifiers.pdslid import PdsLid
 from pds.registrysweepers.utils.productidentifiers.pdslidvid import PdsLidVid
 
+from src.pds.registrysweepers.utils.misc import limit_log_length
+
 log = logging.getLogger(__name__)
 
 # It's necessary to track which registry-refs documents have been processed during this run.  This cannot be derived
@@ -50,7 +52,7 @@ RefDocBookkeepingEntry = namedtuple("RefDocBookkeepingEntry", ["id", "primary_te
 
 
 def get_bundle_ancestry_records(client: OpenSearch, db_mock: DbMockTypeDef = None) -> Iterable[AncestryRecord]:
-    log.info("Generating AncestryRecords for bundles...")
+    log.info(limit_log_length("Generating AncestryRecords for bundles..."))
     docs = get_bundle_ancestry_records_query(client, db_mock)
     for doc in docs:
         try:
@@ -58,13 +60,13 @@ def get_bundle_ancestry_records(client: OpenSearch, db_mock: DbMockTypeDef = Non
             skip_write = sweeper_version_in_doc >= SWEEPERS_ANCESTRY_VERSION
             yield AncestryRecord(lidvid=PdsLidVid.from_string(doc["_source"]["lidvid"]), skip_write=skip_write)
         except (ValueError, KeyError) as err:
-            log.warning(
+            log.warning(limit_log_length(
                 'Failed to instantiate AncestryRecord from document in index "%s" with id "%s" due to %s: %s',
                 doc.get("_index"),
                 doc.get("_id"),
                 type(err),
                 err,
-            )
+            ))
             continue
 
 
@@ -79,13 +81,13 @@ def get_ancestry_by_collection_lidvid(collections_docs: Iterable[Dict]) -> Mappi
             lidvid = PdsLidVid.from_string(doc["_source"]["lidvid"])
             ancestry_by_collection_lidvid[lidvid] = AncestryRecord(lidvid=lidvid, skip_write=skip_write)
         except (ValueError, KeyError) as err:
-            log.warning(
+            log.warning(limit_log_length(
                 'Failed to instantiate AncestryRecord from document in index "%s" with id "%s" due to %s: %s',
                 doc.get("_index"),
                 doc.get("_id"),
                 type(err),
                 err,
-            )
+            ))
             continue
 
     return ancestry_by_collection_lidvid
@@ -108,7 +110,7 @@ def get_ancestry_by_collection_lid(
 def get_collection_ancestry_records(
     client: OpenSearch, registry_db_mock: DbMockTypeDef = None
 ) -> Iterable[AncestryRecord]:
-    log.info("Generating AncestryRecords for collections...")
+    log.info(limit_log_length("Generating AncestryRecords for collections..."))
     bundles_docs = get_collection_ancestry_records_bundles_query(client, registry_db_mock)
     collections_docs = list(get_collection_ancestry_records_collections_query(client, registry_db_mock))
 
@@ -129,13 +131,13 @@ def get_collection_ancestry_records(
                 for id in coerce_list_type(doc["_source"]["ref_lid_collection"])
             ]
         except (ValueError, KeyError) as err:
-            log.warning(
+            log.warning(limit_log_length(
                 'Failed to parse LIDVID and/or collection reference identifiers from document in index "%s" with id "%s" due to %s: %s',
                 doc.get("_index"),
                 doc.get("_id"),
                 type(err),
                 err,
-            )
+            ))
             continue
 
         # For each identifier
@@ -146,19 +148,19 @@ def get_collection_ancestry_records(
                 try:
                     ancestry_by_collection_lidvid[identifier].parent_bundle_lidvids.add(bundle_lidvid)
                 except KeyError:
-                    log.warning(
+                    log.warning(limit_log_length(
                         f"Collection {identifier} referenced by bundle {bundle_lidvid} "
                         f"does not exist in registry - skipping"
-                    )
+                    ))
             elif isinstance(identifier, PdsLid):
                 try:
                     for record in ancestry_by_collection_lid[identifier.lid]:
                         record.parent_bundle_lidvids.add(bundle_lidvid)
                 except KeyError:
-                    log.warning(
+                    log.warning(limit_log_length(
                         f"No versions of collection {identifier} referenced by bundle {bundle_lidvid} "
                         f"exist in registry - skipping"
-                    )
+                    ))
             else:
                 raise RuntimeError(
                     f"Encountered product identifier of unknown type {identifier.__class__} "
@@ -187,12 +189,12 @@ def generate_nonaggregate_and_collection_records_iteratively(
 
     for lid, collections_records_for_lid in collection_records_by_lid.items():
         if all([record.skip_write for record in collections_records_for_lid]):
-            log.debug(f"Skipping updates for up-to-date collection family: {str(lid)}")
+            log.debug(limit_log_length(f"Skipping updates for up-to-date collection family: {str(lid)}"))
             continue
         else:
-            log.info(
+            log.info(limit_log_length(
                 f"Processing all versions of collection {str(lid)}: {[str(id) for id in sorted([r.lidvid for r in collections_records_for_lid])]}"
-            )
+            ))
 
         for non_aggregate_record in get_nonaggregate_ancestry_records_for_collection_lid(
             client, lid, collections_records_for_lid, registry_db_mock
@@ -223,9 +225,9 @@ def get_nonaggregate_ancestry_records_for_collection_lid(
     collection_ancestry_records: Iterable[AncestryRecord],
     registry_db_mock: DbMockTypeDef = None,
 ) -> Iterable[AncestryRecord]:
-    log.info(
+    log.info(limit_log_length(
         f"Generating AncestryRecords for non-aggregate products of collections with LID {str(collection_lid)}, using non-chunked input/output..."
-    )
+    ))
 
     # Generate lookup for the parent bundles of all collections - these will be applied to non-aggregate products too.
     bundle_ancestry_by_collection_lidvid = {
@@ -241,7 +243,7 @@ def get_nonaggregate_ancestry_records_for_collection_lid(
     for doc in collection_refs_query_docs:
         try:
             if doc["_id"].split("::")[2].startswith("S"):
-                log.info(f'Skipping secondary-collection document {doc["_id"]}')
+                log.info(limit_log_length(f'Skipping secondary-collection document {doc["_id"]}'))
                 continue
 
             collection_lidvid = PdsLidVid.from_string(doc["_source"]["collection_lidvid"])
@@ -250,29 +252,29 @@ def get_nonaggregate_ancestry_records_for_collection_lid(
 
             erroneous_lidvids = [id for id in referenced_lidvids if not id.is_basic_product()]
             if len(erroneous_lidvids) > 0:
-                log.error(
+                log.error(limit_log_length(
                     f'registry-refs document with id {doc["_id"]} references one or more aggregate products in its product_lidvid refs list: {[str(id) for id in erroneous_lidvids]}'
-                )
+                ))
 
         except IndexError as err:
             doc_id = doc["_id"]
-            log.warning(f'Encountered document with unexpected _id: "{doc_id}"')
+            log.warning(limit_log_length(f'Encountered document with unexpected _id: "{doc_id}"'))
         except (ValueError, KeyError) as err:
-            log.warning(
+            log.warning(limit_log_length(
                 'Failed to parse collection and/or product LIDVIDs from document in index "%s" with id "%s" due to %s: %s',
                 doc.get("_index"),
                 doc.get("_id"),
                 type(err).__name__,
                 err,
-            )
+            ))
             continue
 
         try:
             bundle_ancestry = bundle_ancestry_by_collection_lidvid[collection_lidvid]
         except KeyError:
-            log.debug(
+            log.debug(limit_log_length(
                 f'Failed to resolve history for page {doc.get("_id")} in index {doc.get("_index")} with collection_lidvid {collection_lidvid} - no such collection exists in registry.'
-            )
+            ))
             continue
 
         for lidvid in nonaggregate_lidvids:
@@ -291,7 +293,7 @@ def _get_nonaggregate_ancestry_records_without_chunking(
     collection_ancestry_records: Iterable[AncestryRecord],
     registry_db_mock: DbMockTypeDef = None,
 ) -> Iterable[AncestryRecord]:
-    log.info("Generating AncestryRecords for non-aggregate products, using non-chunked input/output...")
+    log.info(limit_log_length("Generating AncestryRecords for non-aggregate products, using non-chunked input/output..."))
 
     # Generate lookup for the parent bundles of all collections - these will be applied to non-aggregate products too.
     bundle_ancestry_by_collection_lidvid = {
@@ -305,27 +307,27 @@ def _get_nonaggregate_ancestry_records_without_chunking(
     for doc in collection_refs_query_docs:
         try:
             if doc["_id"].split("::")[2].startswith("S"):
-                log.info(f'Skipping secondary-collection document {doc["_id"]}')
+                log.info(limit_log_length(f'Skipping secondary-collection document {doc["_id"]}'))
                 continue
 
             collection_lidvid = PdsLidVid.from_string(doc["_source"]["collection_lidvid"])
             nonaggregate_lidvids = [PdsLidVid.from_string(s) for s in doc["_source"]["product_lidvid"]]
         except (ValueError, KeyError) as err:
-            log.warning(
+            log.warning(limit_log_length(
                 'Failed to parse collection and/or product LIDVIDs from document in index "%s" with id "%s" due to %s: %s',
                 doc.get("_index"),
                 doc.get("_id"),
                 type(err).__name__,
                 err,
-            )
+            ))
             continue
 
         try:
             bundle_ancestry = bundle_ancestry_by_collection_lidvid[collection_lidvid]
         except KeyError:
-            log.debug(
+            log.debug(limit_log_length(
                 f'Failed to resolve history for page {doc.get("_id")} in index {doc.get("_index")} with collection_lidvid {collection_lidvid} - no such collection exists in registry.'
-            )
+            ))
             continue
 
         for lidvid in nonaggregate_lidvids:
@@ -344,7 +346,7 @@ def _get_nonaggregate_ancestry_records_with_chunking(
     collection_ancestry_records: Iterable[AncestryRecord],
     registry_db_mock: DbMockTypeDef = None,
 ) -> Iterable[AncestryRecord]:
-    log.info("Generating AncestryRecords for non-aggregate products, using chunked input/output...")
+    log.info(limit_log_length("Generating AncestryRecords for non-aggregate products, using chunked input/output..."))
 
     # Generate lookup for the parent bundles of all collections - these will be applied to non-aggregate products too.
     bundle_ancestry_by_collection_lidvid = {
@@ -357,7 +359,7 @@ def _get_nonaggregate_ancestry_records_with_chunking(
         os.makedirs(on_disk_cache_dir, exist_ok=True)
     else:
         on_disk_cache_dir = tempfile.mkdtemp(prefix="ancestry-merge-dump_")
-    log.debug(f"dumping partial non-aggregate ancestry result-sets to {on_disk_cache_dir}")
+    log.debug(limit_log_length(f"dumping partial non-aggregate ancestry result-sets to {on_disk_cache_dir}"))
 
     collection_refs_query_docs = get_nonaggregate_ancestry_records_query(client, registry_db_mock)
     touched_ref_documents: List[RefDocBookkeepingEntry] = []
@@ -368,9 +370,9 @@ def _get_nonaggregate_ancestry_records_with_chunking(
     disk_dump_memory_threshold = baseline_memory_usage + (
         available_processing_memory / 3.0
     )  # peak expected memory use is during merge, where two dump files are open simultaneously. 1.0 added for overhead after testing revealed 2.5 was insufficient
-    log.info(
+    log.info(limit_log_length(
         f"Max memory use set at {user_configured_max_memory_usage}% - dumps will trigger when memory usage reaches {disk_dump_memory_threshold:.1f}%"
-    )
+    ))
     chunk_size_max = (
         0  # populated based on the largest encountered chunk.  see split_chunk_if_oversized() for explanation
     )
@@ -386,9 +388,9 @@ def _get_nonaggregate_ancestry_records_with_chunking(
             try:
                 bundle_ancestry = bundle_ancestry_by_collection_lidvid[collection_lidvid]
             except KeyError:
-                log.debug(
+                log.debug(limit_log_length(
                     f'Failed to resolve history for page {doc.get("_id")} in index {doc.get("_index")} with collection_lidvid {collection_lidvid} - no such collection exists in registry.'
-                )
+                ))
                 continue
 
             for nonaggregate_lidvid_str in doc["_source"]["product_lidvid"]:
@@ -404,9 +406,9 @@ def _get_nonaggregate_ancestry_records_with_chunking(
                 record_dict["parent_collection_lidvids"].add(str(collection_lidvid))
 
                 if psutil.virtual_memory().percent >= disk_dump_memory_threshold:
-                    log.info(
+                    log.info(limit_log_length(
                         f"Memory threshold {disk_dump_memory_threshold:.1f}% reached - dumping serialized history to disk for {len(nonaggregate_ancestry_records_by_lidvid)} products"
-                    )
+                    ))
                     make_history_serializable(nonaggregate_ancestry_records_by_lidvid)
                     dump_history_to_disk(on_disk_cache_dir, nonaggregate_ancestry_records_by_lidvid)
                     chunk_size_max = max(
@@ -431,7 +433,7 @@ def _get_nonaggregate_ancestry_records_with_chunking(
             else:
                 probable_cause = f"Unknown error due to {type(err).__name__}: {err}"
 
-            log.warning(probable_cause)
+            log.warning(limit_log_length(probable_cause))
             continue
 
     # don't forget to yield non-disk-dumped records
@@ -441,16 +443,16 @@ def _get_nonaggregate_ancestry_records_with_chunking(
         try:
             yield AncestryRecord.from_dict(history_dict)
         except ValueError as err:
-            log.warning(err)
+            log.warning(limit_log_length(err))
     del nonaggregate_ancestry_records_by_lidvid
     gc.collect()
 
     # merge/yield the disk-dumped records
     remaining_chunk_filepaths = list(os.path.join(on_disk_cache_dir, fn) for fn in os.listdir(on_disk_cache_dir))
     disk_swap_space_utilized_gb = sum(os.stat(filepath).st_size for filepath in remaining_chunk_filepaths) / 1024**3
-    log.info(
+    log.info(limit_log_length(
         f"On-disk swap comprised of {len(remaining_chunk_filepaths)} files totalling {disk_swap_space_utilized_gb:.1f}GB"
-    )
+    ))
     while len(remaining_chunk_filepaths) > 0:
         # use of pop() here is important - see comment in merge_matching_history_chunks() where
         # ancestry.utils.split_chunk_if_oversized() is called, for justification

--- a/src/pds/registrysweepers/ancestry/utils.py
+++ b/src/pds/registrysweepers/ancestry/utils.py
@@ -19,16 +19,18 @@ from pds.registrysweepers.ancestry.versioning import SWEEPERS_ANCESTRY_VERSION
 from pds.registrysweepers.ancestry.versioning import SWEEPERS_ANCESTRY_VERSION_METADATA_KEY
 from pds.registrysweepers.utils.db import Update
 
+from src.pds.registrysweepers.utils.misc import limit_log_length
+
 log = logging.getLogger(__name__)
 
 
 def make_history_serializable(history: Dict[str, Dict[str, Union[str, Set[str], List[str]]]]):
     """Convert history with set attributes into something able to be dumped to JSON"""
-    log.debug("Converting history into serializable types...")
+    log.debug(limit_log_length("Converting history into serializable types..."))
     for lidvid in history.keys():
         history[lidvid]["parent_bundle_lidvids"] = list(history[lidvid]["parent_bundle_lidvids"])
         history[lidvid]["parent_collection_lidvids"] = list(history[lidvid]["parent_collection_lidvids"])
-    log.debug("    complete!")
+    log.debug(limit_log_length("    complete!"))
 
 
 def load_history_from_filepath(filepath) -> Dict[str, SerializableAncestryRecordTypeDef]:
@@ -44,22 +46,22 @@ def write_history_to_filepath(history: Dict[str, SerializableAncestryRecordTypeD
 def dump_history_to_disk(parent_dir: str, history: Dict[str, SerializableAncestryRecordTypeDef]) -> str:
     """Dump set of history records to disk and return the filepath"""
     output_filepath = os.path.join(parent_dir, datetime.now().isoformat().replace(":", "-"))
-    log.debug(f"Dumping history to {output_filepath} for later merging...")
+    log.debug(limit_log_length(f"Dumping history to {output_filepath} for later merging..."))
     write_history_to_filepath(history, output_filepath)
-    log.debug("    complete!")
+    log.debug(limit_log_length("    complete!"))
 
     return output_filepath
 
 
 def merge_matching_history_chunks(dest_fp: str, src_fps: List[str], max_chunk_size: Union[int, None] = None):
-    log.debug(f"Performing merges into {dest_fp} using max_chunk_size={max_chunk_size}")
+    log.debug(limit_log_length(f"Performing merges into {dest_fp} using max_chunk_size={max_chunk_size}"))
     dest_file_content = load_history_from_filepath(dest_fp)
 
     dest_file_updated = False
 
     for src_fn in src_fps:
         src_file_size_mb = os.stat(src_fn).st_size / 1024**2
-        log.debug(f"merging from {src_fn} ({int(src_file_size_mb)}MB)...")
+        log.debug(limit_log_length(f"merging from {src_fn} ({int(src_file_size_mb)}MB)..."))
         src_file_content = load_history_from_filepath(src_fn)
 
         src_file_updated = False
@@ -104,7 +106,7 @@ def merge_matching_history_chunks(dest_fp: str, src_fps: List[str], max_chunk_si
         # Overwrite the content of the destination file with updated history including absorbed elements
         write_history_to_filepath(dest_file_content, dest_fp)
 
-    log.debug("    complete!")
+    log.debug(limit_log_length("    complete!"))
 
 
 def split_content_chunk_if_oversized(
@@ -128,7 +130,7 @@ def split_content_chunk_if_oversized(
         split_content[k] = content.pop(k)
 
     split_filepath = dump_history_to_disk(parent_dir, split_content)
-    log.debug(f"split off excess chunk content to new file: {split_filepath}")
+    log.debug(limit_log_length(f"split off excess chunk content to new file: {split_filepath}"))
     return split_filepath
 
 

--- a/src/pds/registrysweepers/ancestry/utils.py
+++ b/src/pds/registrysweepers/ancestry/utils.py
@@ -19,7 +19,7 @@ from pds.registrysweepers.ancestry.versioning import SWEEPERS_ANCESTRY_VERSION
 from pds.registrysweepers.ancestry.versioning import SWEEPERS_ANCESTRY_VERSION_METADATA_KEY
 from pds.registrysweepers.utils.db import Update
 
-from src.pds.registrysweepers.utils.misc import limit_log_length
+from pds.registrysweepers.utils.misc import limit_log_length
 
 log = logging.getLogger(__name__)
 

--- a/src/pds/registrysweepers/ancestry/utils.py
+++ b/src/pds/registrysweepers/ancestry/utils.py
@@ -18,7 +18,6 @@ from pds.registrysweepers.ancestry.typedefs import SerializableAncestryRecordTyp
 from pds.registrysweepers.ancestry.versioning import SWEEPERS_ANCESTRY_VERSION
 from pds.registrysweepers.ancestry.versioning import SWEEPERS_ANCESTRY_VERSION_METADATA_KEY
 from pds.registrysweepers.utils.db import Update
-
 from pds.registrysweepers.utils.misc import limit_log_length
 
 log = logging.getLogger(__name__)

--- a/src/pds/registrysweepers/driver.py
+++ b/src/pds/registrysweepers/driver.py
@@ -72,6 +72,8 @@ from pds.registrysweepers.utils.db.client import get_opensearch_client_from_envi
 from pds.registrysweepers.utils.misc import get_human_readable_elapsed_since
 from pds.registrysweepers.utils.misc import is_dev_mode
 
+from src.pds.registrysweepers.utils.misc import limit_log_length
+
 
 def run():
     configure_logging(filepath=None, log_level=logging.INFO)
@@ -79,7 +81,7 @@ def run():
 
     dev_mode = is_dev_mode()
     if dev_mode:
-        log.warning("Operating in development mode - host verification disabled")
+        log.warning(limit_log_length("Operating in development mode - host verification disabled"))
         import urllib3
 
         urllib3.disable_warnings()
@@ -119,7 +121,7 @@ def run():
             sweepers.append(sweeper)
 
     sweeper_descriptions = [inspect.getmodule(f).__name__ for f in sweepers]
-    log.info(f"Running sweepers: {sweeper_descriptions}")
+    log.info(limit_log_length(f"Running sweepers: {sweeper_descriptions}"))
 
     total_execution_begin = datetime.now()
 
@@ -136,7 +138,7 @@ def run():
             f"{sweeper_name}: {get_human_readable_elapsed_since(sweeper_execution_begin)}"
         )
 
-    log.info(
+    log.info(limit_log_length(
         f"Sweepers successfully executed in {get_human_readable_elapsed_since(total_execution_begin)}\n   "
         + "\n   ".join(sweeper_execution_duration_strs)
-    )
+    ))

--- a/src/pds/registrysweepers/driver.py
+++ b/src/pds/registrysweepers/driver.py
@@ -72,7 +72,7 @@ from pds.registrysweepers.utils.db.client import get_opensearch_client_from_envi
 from pds.registrysweepers.utils.misc import get_human_readable_elapsed_since
 from pds.registrysweepers.utils.misc import is_dev_mode
 
-from src.pds.registrysweepers.utils.misc import limit_log_length
+from pds.registrysweepers.utils.misc import limit_log_length
 
 
 def run():

--- a/src/pds/registrysweepers/driver.py
+++ b/src/pds/registrysweepers/driver.py
@@ -71,7 +71,6 @@ from pds.registrysweepers.utils import parse_log_level
 from pds.registrysweepers.utils.db.client import get_opensearch_client_from_environment
 from pds.registrysweepers.utils.misc import get_human_readable_elapsed_since
 from pds.registrysweepers.utils.misc import is_dev_mode
-
 from pds.registrysweepers.utils.misc import limit_log_length
 
 
@@ -138,7 +137,9 @@ def run():
             f"{sweeper_name}: {get_human_readable_elapsed_since(sweeper_execution_begin)}"
         )
 
-    log.info(limit_log_length(
-        f"Sweepers successfully executed in {get_human_readable_elapsed_since(total_execution_begin)}\n   "
-        + "\n   ".join(sweeper_execution_duration_strs)
-    ))
+    log.info(
+        limit_log_length(
+            f"Sweepers successfully executed in {get_human_readable_elapsed_since(total_execution_begin)}\n   "
+            + "\n   ".join(sweeper_execution_duration_strs)
+        )
+    )

--- a/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
@@ -12,7 +12,7 @@ from pds.registrysweepers.utils import configure_logging
 from pds.registrysweepers.utils.misc import is_dev_mode
 from solr_to_es.solrSource import SlowSolrDocs  # type: ignore
 
-from src.pds.registrysweepers.utils.misc import limit_log_length
+from pds.registrysweepers.utils.misc import limit_log_length
 
 log = logging.getLogger(__name__)
 

--- a/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
@@ -12,6 +12,8 @@ from pds.registrysweepers.utils import configure_logging
 from pds.registrysweepers.utils.misc import is_dev_mode
 from solr_to_es.solrSource import SlowSolrDocs  # type: ignore
 
+from src.pds.registrysweepers.utils.misc import limit_log_length
+
 log = logging.getLogger(__name__)
 
 SOLR_URL = "https://pds.nasa.gov/services/search/search"
@@ -27,9 +29,9 @@ def create_legacy_registry_index(es_conn=None):
     @return:
     """
     if not es_conn.indices.exists(OS_INDEX):
-        log.info("create index %s", OS_INDEX)
+        log.info(limit_log_length("create index %s", OS_INDEX))
         es_conn.indices.create(index=OS_INDEX, body={})
-    log.info("index created %s", OS_INDEX)
+    log.info(limit_log_length("index created %s", OS_INDEX))
 
 
 def run(
@@ -62,7 +64,7 @@ def run(
         client, es_actions, chunk_size=50, max_chunk_bytes=50000000, max_retries=5, initial_backoff=10
     ):
         if not operation_successful:
-            log.error(operation_info)
+            log.error(limit_log_length(operation_info))
 
         if dev_mode:
             break

--- a/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
@@ -10,9 +10,8 @@ from pds.registrysweepers.legacy_registry_sync.opensearch_loaded_product import 
 from pds.registrysweepers.legacy_registry_sync.solr_doc_export_to_opensearch import SolrOsWrapperIter
 from pds.registrysweepers.utils import configure_logging
 from pds.registrysweepers.utils.misc import is_dev_mode
-from solr_to_es.solrSource import SlowSolrDocs  # type: ignore
-
 from pds.registrysweepers.utils.misc import limit_log_length
+from solr_to_es.solrSource import SlowSolrDocs  # type: ignore
 
 log = logging.getLogger(__name__)
 

--- a/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
@@ -100,7 +100,7 @@ class SolrOsWrapperIter:
                 except ValueError:
                     log.warning(
                         limit_log_length(
-                            "Date %s for field %s is invalid, assign default datetime 01-01-1950 instead", v, k
+                            f"Date {v} for field {k} is invalid, assign default datetime 01-01-1950 instead"
                         )
                     )
                     new_doc["_source"][k] = [datetime(1950, 1, 1, 0, 0, 0)]
@@ -108,7 +108,7 @@ class SolrOsWrapperIter:
                 if len(v[0]) > 0:
                     new_doc["_source"][k] = v
                 else:
-                    log.warning(limit_log_length("Year %s for field %s is invalid", v, k))
+                    log.warning(limit_log_length(f"Year {v} for field {k} is invalid"))
             else:
                 new_doc["_source"][k] = v
 

--- a/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
@@ -98,7 +98,11 @@ class SolrOsWrapperIter:
                     v = [datetime.fromisoformat(v[0].replace("Z", ""))]
                     new_doc["_source"][k] = v
                 except ValueError:
-                    log.warning(limit_log_length("Date %s for field %s is invalid, assign default datetime 01-01-1950 instead", v, k))
+                    log.warning(
+                        limit_log_length(
+                            "Date %s for field %s is invalid, assign default datetime 01-01-1950 instead", v, k
+                        )
+                    )
                     new_doc["_source"][k] = [datetime(1950, 1, 1, 0, 0, 0)]
             elif "year" in k:
                 if len(v[0]) > 0:

--- a/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
@@ -2,7 +2,7 @@ import logging
 import os
 from datetime import datetime
 
-from src.pds.registrysweepers.utils.misc import limit_log_length
+from pds.registrysweepers.utils.misc import limit_log_length
 
 log = logging.getLogger(__name__)
 

--- a/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/solr_doc_export_to_opensearch.py
@@ -2,6 +2,8 @@ import logging
 import os
 from datetime import datetime
 
+from src.pds.registrysweepers.utils.misc import limit_log_length
+
 log = logging.getLogger(__name__)
 
 NODE_FOLDERS = {
@@ -96,13 +98,13 @@ class SolrOsWrapperIter:
                     v = [datetime.fromisoformat(v[0].replace("Z", ""))]
                     new_doc["_source"][k] = v
                 except ValueError:
-                    log.warning("Date %s for field %s is invalid, assign default datetime 01-01-1950 instead", v, k)
+                    log.warning(limit_log_length("Date %s for field %s is invalid, assign default datetime 01-01-1950 instead", v, k))
                     new_doc["_source"][k] = [datetime(1950, 1, 1, 0, 0, 0)]
             elif "year" in k:
                 if len(v[0]) > 0:
                     new_doc["_source"][k] = v
                 else:
-                    log.warning("Year %s for field %s is invalid", v, k)
+                    log.warning(limit_log_length("Year %s for field %s is invalid", v, k))
             else:
                 new_doc["_source"][k] = v
 
@@ -123,4 +125,4 @@ class SolrOsWrapperIter:
                 doc = next(self.solr_itr)
                 return self.solr_doc_to_os_doc(doc)
             except MissingIdentifierError as e:
-                log.warning(str(e))
+                log.warning(limit_log_length(str(e)))

--- a/src/pds/registrysweepers/provenance/__init__.py
+++ b/src/pds/registrysweepers/provenance/__init__.py
@@ -68,10 +68,9 @@ from pds.registrysweepers.utils.db.update import Update
 from pds.registrysweepers.utils.misc import chunked
 from pds.registrysweepers.utils.misc import get_ids_list_str
 from pds.registrysweepers.utils.misc import group_by_key
+from pds.registrysweepers.utils.misc import limit_log_length
 from pds.registrysweepers.utils.productidentifiers.pdslid import PdsLid
 from tqdm import tqdm
-
-from pds.registrysweepers.utils.misc import limit_log_length
 
 log = logging.getLogger(__name__)
 
@@ -100,9 +99,11 @@ def get_records_for_lids(client: OpenSearch, lids: Collection[PdsLid]) -> Iterab
         try:
             yield ProvenanceRecord.from_doc(doc)
         except ValueError as err:
-            log.warning(limit_log_length(
-                f'Failed to parse ProvenanceRecord from doc with id {doc["_id"]} due to {err} - source was {doc["_source"]}'
-            ))
+            log.warning(
+                limit_log_length(
+                    f'Failed to parse ProvenanceRecord from doc with id {doc["_id"]} due to {err} - source was {doc["_source"]}'
+                )
+            )
 
 
 def fetch_target_lids(client: OpenSearch) -> Iterable[PdsLid]:
@@ -295,9 +296,11 @@ def generate_updates(records: Iterable[ProvenanceRecord]) -> Iterable[Update]:
 
         yield Update(id=str(record.lidvid), content=update_content, skip_write=record.skip_write)
 
-    log.info(limit_log_length(
-        f"Generated provenance updates for {update_count} products, ({skippable_count} up-to-date products will be skipped)"
-    ))
+    log.info(
+        limit_log_length(
+            f"Generated provenance updates for {update_count} products, ({skippable_count} up-to-date products will be skipped)"
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/src/pds/registrysweepers/provenance/__init__.py
+++ b/src/pds/registrysweepers/provenance/__init__.py
@@ -71,7 +71,7 @@ from pds.registrysweepers.utils.misc import group_by_key
 from pds.registrysweepers.utils.productidentifiers.pdslid import PdsLid
 from tqdm import tqdm
 
-from src.pds.registrysweepers.utils.misc import limit_log_length
+from pds.registrysweepers.utils.misc import limit_log_length
 
 log = logging.getLogger(__name__)
 

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -23,7 +23,7 @@ from pds.registrysweepers.utils.db.multitenancy import resolve_multitenant_index
 from pds.registrysweepers.utils.db.update import Update
 from tqdm import tqdm
 
-from src.pds.registrysweepers.utils.misc import limit_log_length
+from pds.registrysweepers.utils.misc import limit_log_length
 
 log = logging.getLogger(__name__)
 

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -21,9 +21,8 @@ from pds.registrysweepers.utils.db.client import get_userpass_opensearch_client
 from pds.registrysweepers.utils.db.indexing import ensure_index_mapping
 from pds.registrysweepers.utils.db.multitenancy import resolve_multitenant_index_name
 from pds.registrysweepers.utils.db.update import Update
-from tqdm import tqdm
-
 from pds.registrysweepers.utils.misc import limit_log_length
+from tqdm import tqdm
 
 log = logging.getLogger(__name__)
 
@@ -156,15 +155,19 @@ def accumulate_missing_mappings(
                 and not property_name.startswith("ops:Provenance")
                 and property_name not in canonical_type_undefined_property_names
             ):
-                log.warning(limit_log_length(
-                    f"Property {property_name} does not have an entry in the data dictionary index or hardcoded mappings - this may indicate a problem"
-                ))
+                log.warning(
+                    limit_log_length(
+                        f"Property {property_name} does not have an entry in the data dictionary index or hardcoded mappings - this may indicate a problem"
+                    )
+                )
                 canonical_type_undefined_property_names.add(property_name)
 
             if mapping_is_bad and property_name not in bad_mapping_property_names:
-                log.warning(limit_log_length(
-                    f'Property {property_name} is defined in data dictionary index or hardcoded mappings as type "{canonical_type}" but exists in index mapping as type "{current_mapping_type}")'
-                ))
+                log.warning(
+                    limit_log_length(
+                        f'Property {property_name} is defined in data dictionary index or hardcoded mappings as type "{canonical_type}" but exists in index mapping as type "{current_mapping_type}")'
+                    )
+                )
                 bad_mapping_property_names.add(property_name)
 
             if (mapping_missing or mapping_is_bad) and not problem_detected_in_document_already:
@@ -181,9 +184,11 @@ def accumulate_missing_mappings(
                         doc_harvest_time, latest_problem_doc_harvested_at or doc_harvest_time
                     )
                 except (KeyError, ValueError) as err:
-                    log.warning(limit_log_length(
-                        f'Unable to parse first element of "ops:Harvest_Info/ops:harvest_date_time" as ISO-formatted date from document {doc["_id"]}: {attr_value} ({err})'
-                    ))
+                    log.warning(
+                        limit_log_length(
+                            f'Unable to parse first element of "ops:Harvest_Info/ops:harvest_date_time" as ISO-formatted date from document {doc["_id"]}: {attr_value} ({err})'
+                        )
+                    )
 
                 try:
                     problematic_harvest_versions.update(doc["_source"]["ops:Harvest_Info/ops:harvest_version"])
@@ -194,9 +199,11 @@ def accumulate_missing_mappings(
 
             if mapping_missing and property_name not in missing_mapping_updates:
                 if canonical_type_is_defined:
-                    log.info(limit_log_length(
-                        f'Property {property_name} will be updated to type "{canonical_type}" from data dictionary'
-                    ))
+                    log.info(
+                        limit_log_length(
+                            f'Property {property_name} will be updated to type "{canonical_type}" from data dictionary'
+                        )
+                    )
                     missing_mapping_updates[property_name] = canonical_type  # type: ignore
                 elif property_name.startswith(
                     "ops:Provenance"
@@ -204,40 +211,54 @@ def accumulate_missing_mappings(
                     # mappings for registry-sweepers are the responsibility of their respective sweepers and should not
                     # be touched by the reindexer sweeper
                     if property_name not in sweepers_missing_property_names:
-                        log.warning(limit_log_length(
-                            f"Property {property_name} is missing from the index mapping, but is a sweepers metadata attribute and will not be fixed here. Please run the full set of sweepers on this index"
-                        ))
+                        log.warning(
+                            limit_log_length(
+                                f"Property {property_name} is missing from the index mapping, but is a sweepers metadata attribute and will not be fixed here. Please run the full set of sweepers on this index"
+                            )
+                        )
                         sweepers_missing_property_names.add(property_name)
                 else:
                     # if there is no canonical type and it is not a provenance metadata key, do nothing, per jpadams
                     pass
 
-    log.info(limit_log_length(
-        f"RESULT: Detected {format_hits_count(problem_docs_count)} docs with {len(missing_mapping_updates)} missing mappings and {len(bad_mapping_property_names)} mappings conflicting with the DD, out of a total of {format_hits_count(total_docs_count)} docs"
-    ))
+    log.info(
+        limit_log_length(
+            f"RESULT: Detected {format_hits_count(problem_docs_count)} docs with {len(missing_mapping_updates)} missing mappings and {len(bad_mapping_property_names)} mappings conflicting with the DD, out of a total of {format_hits_count(total_docs_count)} docs"
+        )
+    )
 
     if problem_docs_count > 0:
-        log.warning(limit_log_length(
-            f"RESULT: Problems were detected with docs having harvest timestamps between {earliest_problem_doc_harvested_at.isoformat()} and {latest_problem_doc_harvested_at.isoformat()}"  # type: ignore
-        ))
-        log.warning(limit_log_length(
-            f"RESULT: Problems were detected with docs having harvest versions {sorted(problematic_harvest_versions)}"
-        ))
+        log.warning(
+            limit_log_length(
+                f"RESULT: Problems were detected with docs having harvest timestamps between {earliest_problem_doc_harvested_at.isoformat()} and {latest_problem_doc_harvested_at.isoformat()}"  # type: ignore
+            )
+        )
+        log.warning(
+            limit_log_length(
+                f"RESULT: Problems were detected with docs having harvest versions {sorted(problematic_harvest_versions)}"
+            )
+        )
 
     if len(missing_mapping_updates) > 0:
-        log.info(limit_log_length(
-            f"RESULT: Mappings will be added for the following properties: {sorted(missing_mapping_updates.keys())}"
-        ))
+        log.info(
+            limit_log_length(
+                f"RESULT: Mappings will be added for the following properties: {sorted(missing_mapping_updates.keys())}"
+            )
+        )
 
     if len(canonical_type_undefined_property_names) > 0:
-        log.info(limit_log_length(
-            f"RESULT: Mappings were not found in the DD or static types for the following properties: {sorted(canonical_type_undefined_property_names)}"
-        ))
+        log.info(
+            limit_log_length(
+                f"RESULT: Mappings were not found in the DD or static types for the following properties: {sorted(canonical_type_undefined_property_names)}"
+            )
+        )
 
     if len(bad_mapping_property_names) > 0:
-        log.error(limit_log_length(
-            f"RESULT: The following mappings have a type which does not match the type described by the data dictionary: {bad_mapping_property_names} - in-place update is not possible, data will need to be manually reindexed with manual updates (or that functionality must be added to this sweeper"
-        ))
+        log.error(
+            limit_log_length(
+                f"RESULT: The following mappings have a type which does not match the type described by the data dictionary: {bad_mapping_property_names} - in-place update is not possible, data will need to be manually reindexed with manual updates (or that functionality must be added to this sweeper"
+            )
+        )
 
     return missing_mapping_updates
 
@@ -323,7 +344,11 @@ def run(
                 ),
             )
             for property, mapping_typename in missing_mappings.items():
-                log.info(limit_log_length(f"Updating index {products_index_name} with missing mapping ({property}, {mapping_typename})"))
+                log.info(
+                    limit_log_length(
+                        f"Updating index {products_index_name} with missing mapping ({property}, {mapping_typename})"
+                    )
+                )
                 ensure_index_mapping(client, products_index_name, property, mapping_typename)
 
             updated_mapping_keys = get_mapping_field_types_by_field_name(client, products_index_name).keys()
@@ -339,9 +364,11 @@ def run(
                     sort_fields=sort_fields,
                 ),
             )
-            log.info(limit_log_length(
-                f"Updating newly-processed documents with {REINDEXER_FLAG_METADATA_KEY}={sweeper_start_timestamp.isoformat()}..."
-            ))
+            log.info(
+                limit_log_length(
+                    f"Updating newly-processed documents with {REINDEXER_FLAG_METADATA_KEY}={sweeper_start_timestamp.isoformat()}..."
+                )
+            )
             write_updated_docs(
                 client,
                 updates,

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -26,7 +26,7 @@ from pds.registrysweepers.utils.db.indexing import ensure_index_mapping
 from pds.registrysweepers.utils.db.multitenancy import resolve_multitenant_index_name
 from pds.registrysweepers.utils.db.update import Update
 
-from src.pds.registrysweepers.utils.misc import limit_log_length
+from pds.registrysweepers.utils.misc import limit_log_length
 
 """
 dictionary repair tools is {field_name:[funcs]} where field_name can be:

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -25,7 +25,6 @@ from pds.registrysweepers.utils.db.client import get_userpass_opensearch_client
 from pds.registrysweepers.utils.db.indexing import ensure_index_mapping
 from pds.registrysweepers.utils.db.multitenancy import resolve_multitenant_index_name
 from pds.registrysweepers.utils.db.update import Update
-
 from pds.registrysweepers.utils.misc import limit_log_length
 
 """
@@ -74,9 +73,11 @@ def generate_updates(
 
         document_needed_fixing = len(set(repairs).difference({repairkit_version_metadata_key})) > 0
         if document_needed_fixing and not repair_already_logged_to_error:
-            log.error(limit_log_length(
-                "repairkit sweeper detects documents in need of repair - please ~harass~ *request* node user to update their harvest version"
-            ))
+            log.error(
+                limit_log_length(
+                    "repairkit sweeper detects documents in need of repair - please ~harass~ *request* node user to update their harvest version"
+                )
+            )
             repair_already_logged_to_error = True
         yield Update(id=id, content=repairs)
 

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -26,6 +26,8 @@ from pds.registrysweepers.utils.db.indexing import ensure_index_mapping
 from pds.registrysweepers.utils.db.multitenancy import resolve_multitenant_index_name
 from pds.registrysweepers.utils.db.update import Update
 
+from src.pds.registrysweepers.utils.misc import limit_log_length
+
 """
 dictionary repair tools is {field_name:[funcs]} where field_name can be:
   1: re.compile().fullmatch for the equivalent of "fred" == "fred"
@@ -72,9 +74,9 @@ def generate_updates(
 
         document_needed_fixing = len(set(repairs).difference({repairkit_version_metadata_key})) > 0
         if document_needed_fixing and not repair_already_logged_to_error:
-            log.error(
+            log.error(limit_log_length(
                 "repairkit sweeper detects documents in need of repair - please ~harass~ *request* node user to update their harvest version"
-            )
+            ))
             repair_already_logged_to_error = True
         yield Update(id=id, content=repairs)
 
@@ -85,7 +87,7 @@ def run(
     log_level: int = logging.INFO,
 ):
     configure_logging(filepath=log_filepath, log_level=log_level)
-    log.info(f"Starting repairkit v{SWEEPERS_REPAIRKIT_VERSION} sweeper processing...")
+    log.info(limit_log_length(f"Starting repairkit v{SWEEPERS_REPAIRKIT_VERSION} sweeper processing..."))
 
     def get_unprocessed_docs_query():
         return {
@@ -126,7 +128,7 @@ def run(
             bulk_chunk_max_update_count=update_max_chunk_size,
         )
 
-    log.info("Repairkit sweeper processing complete!")
+    log.info(limit_log_length("Repairkit sweeper processing complete!"))
 
 
 if __name__ == "__main__":

--- a/src/pds/registrysweepers/repairkit/allarrays.py
+++ b/src/pds/registrysweepers/repairkit/allarrays.py
@@ -25,6 +25,10 @@ def repair(document: Dict, fieldname: str) -> Dict:
         return {}
 
     if isinstance(document[fieldname], str):
-        log.debug(limit_log_length(f"found string in doc {document.get('_id')} for field {fieldname} where it should be an array"))
+        log.debug(
+            limit_log_length(
+                f"found string in doc {document.get('_id')} for field {fieldname} where it should be an array"
+            )
+        )
         return {fieldname: [document[fieldname]]}
     return {}

--- a/src/pds/registrysweepers/repairkit/allarrays.py
+++ b/src/pds/registrysweepers/repairkit/allarrays.py
@@ -3,6 +3,8 @@ import json
 import logging
 from typing import Dict
 
+from src.pds.registrysweepers.utils.misc import limit_log_length
+
 log = logging.getLogger(__name__)
 
 # exclude the following properties from array conversion even if targeted - they are expected to be string-typed
@@ -23,6 +25,6 @@ def repair(document: Dict, fieldname: str) -> Dict:
         return {}
 
     if isinstance(document[fieldname], str):
-        log.debug(f"found string in doc {document.get('_id')} for field {fieldname} where it should be an array")
+        log.debug(limit_log_length(f"found string in doc {document.get('_id')} for field {fieldname} where it should be an array"))
         return {fieldname: [document[fieldname]]}
     return {}

--- a/src/pds/registrysweepers/repairkit/allarrays.py
+++ b/src/pds/registrysweepers/repairkit/allarrays.py
@@ -3,7 +3,7 @@ import json
 import logging
 from typing import Dict
 
-from src.pds.registrysweepers.utils.misc import limit_log_length
+from pds.registrysweepers.utils.misc import limit_log_length
 
 log = logging.getLogger(__name__)
 

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -19,7 +19,7 @@ from retry import retry
 from retry.api import retry_call
 from tqdm import tqdm
 
-from src.pds.registrysweepers.utils.misc import limit_log_length
+from pds.registrysweepers.utils.misc import limit_log_length
 
 log = logging.getLogger(__name__)
 

--- a/src/pds/registrysweepers/utils/db/__init__.py
+++ b/src/pds/registrysweepers/utils/db/__init__.py
@@ -19,6 +19,8 @@ from retry import retry
 from retry.api import retry_call
 from tqdm import tqdm
 
+from src.pds.registrysweepers.utils.misc import limit_log_length
+
 log = logging.getLogger(__name__)
 
 
@@ -40,12 +42,12 @@ def query_registry_db_with_scroll(
 
     scroll_keepalive = f"{scroll_keepalive_minutes}m"
     query_id = get_random_hex_id()  # This is just used to differentiate queries during logging
-    log.debug(f"Initiating query (id {query_id}) of index {index_name}: {json.dumps(query)}")
+    log.debug(limit_log_length(f"Initiating query (id {query_id}) of index {index_name}: {json.dumps(query)}"))
 
     served_hits = 0
 
     last_info_log_at_percentage = 0
-    log.debug(f"Query {query_id} progress: 0%")
+    log.debug(limit_log_length(f"Query {query_id} progress: 0%"))
 
     more_data_exists = True
     scroll_id = None
@@ -81,7 +83,7 @@ def query_registry_db_with_scroll(
 
         total_hits = results["hits"]["total"]["value"]
         if served_hits == 0:
-            log.debug(f"Query {query_id} returns {total_hits} total hits")
+            log.debug(limit_log_length(f"Query {query_id} returns {total_hits} total hits"))
 
         response_hits = results["hits"]["hits"]
         for hit in response_hits:
@@ -90,7 +92,7 @@ def query_registry_db_with_scroll(
             percentage_of_hits_served = int(served_hits / total_hits * 100)
             if last_info_log_at_percentage is None or percentage_of_hits_served >= (last_info_log_at_percentage + 5):
                 last_info_log_at_percentage = percentage_of_hits_served
-                log.debug(f"Query {query_id} progress: {percentage_of_hits_served}%")
+                log.debug(limit_log_length(f"Query {query_id} progress: {percentage_of_hits_served}%"))
 
             yield hit
 
@@ -100,9 +102,9 @@ def query_registry_db_with_scroll(
         # TODO: Remove this upon implementation of https://github.com/NASA-PDS/registry-sweepers/issues/42
         hits_data_present_in_response = len(response_hits) > 0
         if not hits_data_present_in_response and served_hits < total_hits:
-            log.error(
+            log.error(limit_log_length(
                 f"Response for query {query_id} contained no hits when hits were expected.  Returned data is incomplete (got {served_hits} of {total_hits} total hits).  Response was: {results}"
-            )
+            ))
             break
 
         more_data_exists = served_hits < results["hits"]["total"]["value"]
@@ -116,7 +118,7 @@ def query_registry_db_with_scroll(
         logger=log,
     )
 
-    log.debug(f"Query {query_id} complete!")
+    log.debug(limit_log_length(f"Query {query_id} complete!"))
 
 
 def query_registry_db_with_search_after(
@@ -143,10 +145,10 @@ def query_registry_db_with_search_after(
 
     # TODO: stop accepted {'query': <content>} and start accepting just <content> itself, to prevent the need for this guard
     if "search_after" in query.keys():
-        log.error(
+        log.error(limit_log_length(
             f'Provided query object contains "search_after" content when none should exist - was a dict object reused?: got {query}.'
-        )
-        log.info("Discarding erroneous search_after values.")
+        ))
+        log.info(limit_log_length("Discarding erroneous search_after values."))
         query.pop("search_after")
 
     query_id = get_random_hex_id()  # This is just used to differentiate queries during logging
@@ -159,7 +161,7 @@ def query_registry_db_with_search_after(
     total_hits = get_query_hits_count(client, index_name, query)
     expected_hits = limit if limit is not None else total_hits
     limit_log_msg_part = f" (limited to {expected_hits} hits)" if limit is not None else ""
-    log.debug(f"Query {query_id} returns {total_hits} total hits{limit_log_msg_part}: {json.dumps(query)}")
+    log.debug(limit_log_length(f"Query {query_id} returns {total_hits} total hits{limit_log_msg_part}: {json.dumps(query)}"))
 
     with tqdm(total=expected_hits, desc=f"Query {query_id}") as pbar:
         while more_data_exists:
@@ -177,9 +179,9 @@ def query_registry_db_with_search_after(
 
             if search_after_values is not None:
                 query["search_after"] = search_after_values
-                log.debug(
+                log.debug(limit_log_length(
                     f"Query {query_id} paging {page_size} hits (page {current_page} of {expected_pages}) with sort fields {sort_fields} and search-after values {search_after_values}"
-                )
+                ))
 
             def fetch_func():
                 return client.search(
@@ -212,7 +214,7 @@ def query_registry_db_with_search_after(
                 yield hit
 
                 if limit is not None and served_hits >= limit:
-                    log.debug(f"Query {query_id} complete! (limit of {expected_hits} hits reached)")
+                    log.debug(limit_log_length(f"Query {query_id} complete! (limit of {expected_hits} hits reached)"))
                     return
 
                 # simpler to set the value after every hit than worry about OBO errors detecting the last hit in the page
@@ -239,14 +241,14 @@ def query_registry_db_with_search_after(
             # TODO: Remove this upon implementation of https://github.com/NASA-PDS/registry-sweepers/issues/42
             hits_data_present_in_response = len(response_hits) > 0
             if not hits_data_present_in_response and served_hits < total_hits:
-                log.error(
+                log.error(limit_log_length(
                     f"Response for query {query_id} contained no hits when hits were expected.  Returned data is incomplete (got {served_hits} of {total_hits} total hits).  Response was: {results}"
-                )
+                ))
                 break
 
             more_data_exists = served_hits < results["hits"]["total"]["value"]
 
-    log.debug(f"Query {query_id} complete!")
+    log.debug(limit_log_length(f"Query {query_id} complete!"))
 
 
 def query_registry_db_or_mock(
@@ -282,7 +284,7 @@ def write_updated_docs(
     bulk_chunk_max_update_count: Union[int, None] = None,
     as_upsert: bool = False,
 ):
-    log.info("Writing document updates...")
+    log.info(limit_log_length("Writing document updates..."))
     buffered_updates_count = 0
     updated_doc_count = 0
     total_writes_skipped = 0
@@ -311,9 +313,9 @@ def write_updated_docs(
         )
 
         if flush_threshold_reached:
-            log.debug(
+            log.debug(limit_log_length(
                 f"Bulk update buffer has reached {threshold_log_str} threshold - writing {buffered_updates_count} document updates to db..."
-            )
+            ))
             _write_bulk_updates_chunk(client, index_name, bulk_updates_buffer)
             bulk_updates_buffer = []
             bulk_buffer_size_mb = 0.0
@@ -328,10 +330,10 @@ def write_updated_docs(
         updated_doc_count += 1
 
     if buffered_updates_count > 0:
-        log.debug(f"Writing documents updates for {buffered_updates_count} remaining products to db...")
+        log.debug(limit_log_length(f"Writing documents updates for {buffered_updates_count} remaining products to db..."))
         _write_bulk_updates_chunk(client, index_name, bulk_updates_buffer)
 
-    log.info(f"Wrote document updates for {updated_doc_count} products and skipped {total_writes_skipped} doc updates")
+    log.info(limit_log_length(f"Wrote document updates for {updated_doc_count} products and skipped {total_writes_skipped} doc updates"))
 
 
 def update_as_statements(update: Update, as_upsert: bool = False) -> Iterable[str]:
@@ -352,7 +354,7 @@ def update_as_statements(update: Update, as_upsert: bool = False) -> Iterable[st
 @retry(tries=6, delay=15, backoff=2, logger=log)
 def _write_bulk_updates_chunk(client: OpenSearch, index_name: str, bulk_updates: List[str]):
     if len(bulk_updates) == 0:
-        log.debug("_write_bulk_updates_chunk received empty arg bulk_updates - skipping")
+        log.debug(limit_log_length("_write_bulk_updates_chunk received empty arg bulk_updates - skipping"))
 
     bulk_data = "\n".join(bulk_updates) + "\n"
 
@@ -378,9 +380,9 @@ def _write_bulk_updates_chunk(client: OpenSearch, index_name: str, bulk_updates:
             for error_type, reason_aggregate in warning_aggregates.items():
                 for error_reason, ids in reason_aggregate.items():
                     ids_str = get_ids_list_str(ids)
-                    log.warning(
+                    log.warning(limit_log_length(
                         f"Attempt to update the following {len(ids)} documents failed due to {error_type} ({error_reason}): {ids_str}"
-                    )
+                    ))
 
         if log.isEnabledFor(logging.ERROR):
             items_with_errors = [
@@ -390,11 +392,11 @@ def _write_bulk_updates_chunk(client: OpenSearch, index_name: str, bulk_updates:
             for error_type, reason_aggregate in error_aggregates.items():
                 for error_reason, ids in reason_aggregate.items():
                     ids_str = get_ids_list_str(ids)
-                    log.error(
+                    log.error(limit_log_length(
                         f"Attempt to update the following {len(ids)} documents failed unexpectedly due to {error_type} ({error_reason}): {ids_str}"
-                    )
+                    ))
     else:
-        log.debug("Successfully wrote bulk update chunk")
+        log.debug(limit_log_length("Successfully wrote bulk update chunk"))
 
 
 def aggregate_update_error_types(items: Iterable[Dict]) -> Mapping[str, Dict[str, List[str]]]:

--- a/src/pds/registrysweepers/utils/misc.py
+++ b/src/pds/registrysweepers/utils/misc.py
@@ -195,8 +195,9 @@ def get_ids_list_str(
     else:
         return f"{display_id_str} <list of {ids_count} ids truncated - enable DEBUG logging or increase display limit in code to see more>"
 
+
 def limit_log_length(log_msg: str, max_str_length: int = 5012) -> str:
     if len(log_msg) > max_str_length:
-        return log_msg[:max_str_length] + ' ... <TRUNCATED>'
+        return log_msg[:max_str_length] + " ... <TRUNCATED>"
     else:
         return log_msg

--- a/src/pds/registrysweepers/utils/misc.py
+++ b/src/pds/registrysweepers/utils/misc.py
@@ -194,3 +194,9 @@ def get_ids_list_str(
         return display_id_str
     else:
         return f"{display_id_str} <list of {ids_count} ids truncated - enable DEBUG logging or increase display limit in code to see more>"
+
+def limit_log_length(log_msg: str, max_str_length: int = 5012) -> str:
+    if len(log_msg) > max_str_length:
+        return log_msg[:max_str_length] + ' ... <TRUNCATED>'
+    else:
+        return log_msg

--- a/tests/pds/registrysweepers/provenance/test_provenance.py
+++ b/tests/pds/registrysweepers/provenance/test_provenance.py
@@ -3,13 +3,12 @@ import json
 import os.path
 import unittest
 
+from build.lib.pds.registrysweepers.provenance.versioning import SWEEPERS_BROKEN_PROVENANCE_VERSION_METADATA_KEY
 from pds.registrysweepers import provenance
 from pds.registrysweepers.provenance import ProvenanceRecord
 from pds.registrysweepers.provenance import SWEEPERS_PROVENANCE_VERSION
 from pds.registrysweepers.provenance import SWEEPERS_PROVENANCE_VERSION_METADATA_KEY
 from pds.registrysweepers.utils.db import Update
-
-from build.lib.pds.registrysweepers.provenance.versioning import SWEEPERS_BROKEN_PROVENANCE_VERSION_METADATA_KEY
 
 
 class ProvenanceBasicFunctionalTestCase(unittest.TestCase):

--- a/tests/pds/registrysweepers/provenance/test_provenance.py
+++ b/tests/pds/registrysweepers/provenance/test_provenance.py
@@ -3,11 +3,11 @@ import json
 import os.path
 import unittest
 
-from build.lib.pds.registrysweepers.provenance.versioning import SWEEPERS_BROKEN_PROVENANCE_VERSION_METADATA_KEY
 from pds.registrysweepers import provenance
 from pds.registrysweepers.provenance import ProvenanceRecord
 from pds.registrysweepers.provenance import SWEEPERS_PROVENANCE_VERSION
 from pds.registrysweepers.provenance import SWEEPERS_PROVENANCE_VERSION_METADATA_KEY
+from pds.registrysweepers.provenance.versioning import SWEEPERS_BROKEN_PROVENANCE_VERSION_METADATA_KEY
 from pds.registrysweepers.utils.db import Update
 
 


### PR DESCRIPTION

## 🗒️ Summary
Wraps all calls to `log.<LEVEL>()` in a length-limiting function.
This is required to further debug the recent many-nodes failures in which large documents are being dumped to the logs, flooding them and rendering them unreadable.

## ⚙️ Test Data and/or Report
Unit tests pass

## ♻️ Related Issues
No related issue so far