### PR TITLE
Upgrade to Python 3.13

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 
 /venv
 
-/venv39
+/venv313
 
 /docs/
 

--- a/.github/workflows/branch_cicd.yaml
+++ b/.github/workflows/branch_cicd.yaml
@@ -42,7 +42,7 @@ jobs:
                 name: Set up Python 3
                 uses: actions/setup-python@v1
                 with:
-                    python-version: '3.9'
+                    python-version: '3.13'
             -
                 name: 💵 Python Cache
                 uses: actions/cache@v3

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@
 # Python build, virtual environments, and buildouts
 .venv
 venv
-venv39
+venv313
 __pycache__/
 dist/
 build/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,14 +26,16 @@ repos:
         language: system
         pass_filenames: false
 
--   repo: local
-    hooks:
-    -   id: black
-        name: black
-        entry: black
-        files: ^src/|tests/
-        language: system
-        types: [python]
+# Disabled "black" because it's conflicting with reorder-python-imports
+#
+# -   repo: local
+#     hooks:
+#     -   id: black
+#         name: black
+#         entry: black
+#         files: ^src/|tests/
+#         language: system
+#         types: [python]
 
 -   repo: local
     hooks:

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,6 +1,6 @@
-PDS XYZ Tool (update licensing below per specific organization)
+PDS Registry Sweepers
 
-Copyright 2021, California Institute of Technology ("Caltech").
+Copyright 2021–2025, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The reindexer sweeper ensures that the registry index mappings are updated with 
 ### Prerequisites
 
 #### Dependencies
-- Python >=3.9
+- Python >=3.13
 
 #### Environment Variables
 ```
@@ -73,70 +73,10 @@ To develop this project, use your favorite text editor, or an integrated develop
 For information on how to contribute to NASA-PDS codebases please take a look at our [Contributing guidelines](https://github.com/NASA-PDS/.github/blob/main/CONTRIBUTING.md).
 
 
-### Installation
-
-Install in editable mode and with extra developer dependencies into your virtual environment of choice:
-
-    pip install --editable '.[dev]'
-
-Configure the `pre-commit` hooks:
-
-    pre-commit install
-    pre-commit install -t pre-push
-    pre-commit install -t prepare-commit-msg
-    pre-commit install -t commit-msg
-
-These hooks check code formatting and also aborts commits that contain secrets such as passwords or API keys. However, a one time setup is required in your global Git configuration. See [the wiki entry on Git Secrets](https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Git-and-Github-Guide#git-secrets) to learn how.
-
-### Packaging
-
-To isolate and be able to re-produce the environment for this package, you should use a [Python Virtual Environment](https://docs.python.org/3/tutorial/venv.html). To do so, run:
-
-    python -m venv venv
-
-Then exclusively use `venv/bin/python`, `venv/bin/pip`, etc.
-
-If you have `tox` installed and would like it to create your environment and install dependencies for you run:
-
-    tox --devenv <name you'd like for env> -e dev
-
-Dependencies for development are specified as the `dev` `extras_require` in `setup.cfg`; they are installed into the virtual environment as follows:
-
-    pip install --editable '.[dev]'
-
-All the source code is in a sub-directory under `src`.
-
-
-### Tests
-
-This section describes testing for your package.
-
-A complete "build" including test execution, linting (`mypy`, `black`, `flake8`, etc.), and documentation build is executed via:
-
-    tox
-
-
-#### Unit tests
-
-Your project should have built-in unit tests, functional, validation, acceptance, etc., tests.
-
-For unit testing, check out the [unittest](https://docs.python.org/3/library/unittest.html) module, built into Python 3.
-
-Tests objects should be in packages `test` modules or preferably in project 'tests' directory which mirrors the project package structure.
-
-Our unit tests are launched with command:
-
-    pytest
-
-If you want your tests to run automatically as you make changes start up `pytest` in watch mode with:
-
-    ptw
-
-
 ## Build
 
-    pip install wheel
-    python setup.py sdist bdist_wheel
+    pip install build
+    python3 -m build .
 
 
 ## Publication
@@ -148,7 +88,7 @@ NASA PDS packages can publish automatically using the [Roundup Action](https://g
 
 Create the package:
 
-    python setup.py bdist_wheel
+    python3 -m build .
 
 Publish it as a Github release.
 
@@ -161,6 +101,7 @@ Or publish on the Test PyPI (you need a Test PyPI account and configure `$HOME/.
 
     pip install twine
     twine upload --repository testpypi dist/*
+
 
 ## CI/CD
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-This document describes the security policy of My Project. (Please update this for your actual project.)
+This document describes the security policy of Registry Sweepers.
 
 
 ## Supported Versions
@@ -9,11 +9,10 @@ Use this section to tell people about which versions of your project are current
 
 | Version | Supported |
 |:--------|:---------:|
-| 2.1.4   | ✅        |
-| 2.1.3   | ✅        |
-| <2.0    | ❌        |
+| 1.5.0   | ✅        |
+| <1.5.0  | ❌        |
 
 
 ## Reporting a Vulnerability
 
-To report a vulnerability, [please submit an issue on our tracker](https://github.com/NASA-PDS/<TODO: put project ID here>/issues/new?template=vulnerability-issue.md).
+To report a vulnerability, [please submit an issue on our tracker](https://github.com/NASA-PDS/registry-sweepers/issues/new?template=vulnerability-issue.md).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,8 +18,8 @@
 # -- Project information -----------------------------------------------------
 
 # TODO - Update with your project name
-project = 'My PDS Project'
-copyright = '2022 California Institute of Technology'
+project = 'PDS Registry Sweepers'
+copyright = '2021–2025 California Institute of Technology'
 author = 'NASA Planetary Data System'
 release = '0.0'
 version = '0.0'
@@ -37,11 +37,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx.ext.autosummary',
-    'sphinx_rtd_theme'
 ]
-
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -79,8 +75,6 @@ html_css_files = [
 
 html_theme_options = {
     'canonical_url': '',
-    'logo_only': False,
-    'display_version': True,
     'prev_next_buttons_location': 'bottom',
     'style_external_links': False,
     # Toc options

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,7 @@ url = https://github.com/NASA-PDS/registry-sweepers
 download_url = https://github.com/NASA-PDS/registry-sweepers/releases/
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
-    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3.13
     Operating System :: OS Independent
 
 
@@ -41,25 +40,22 @@ install_requires =
     python-dateutil~=2.9.0
 
 # Change this to False if you use things like __file__ or __path__—which you
-# shouldn't use anyway, because that's what ``pkg_resources`` is for 🙂
+# shouldn't use anyway, because that's what ``importlib.resources`` is for 🙂
 zip_safe = True
 include_package_data = True
 # base directory for code is in src/. Don't change this.
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >= 3.9
+python_requires = >= 3.13
 
 [options.extras_require]
 dev =
-# later versions of alabaster require sphinx>=3.4
-    alabaster <=0.7.13
-    black~=23.7.0
-    flake8~=6.1.0
-    flake8-bugbear~=23.7.10
+    flake8~=7.3.0
+    flake8-bugbear~=24.12.12
     flake8-docstrings~=1.7.0
     pep8-naming~=0.13.3
-    mypy~=1.5.1
+    mypy~=1.14.1
     pydocstyle~=6.3.0
     coverage~=7.3.0
     pytest~=7.4.0
@@ -67,27 +63,16 @@ dev =
     pytest-watch~=4.2.0
     pytest-xdist~=3.3.1
     pre-commit~=3.3.3
-    sphinx~=3.2.1
-    sphinx-rtd-theme~=0.5.0
+    sphinx~=8.2.3
+    sphinx-rtd-theme~=3.0.2
     types-python-dateutil==2.9.0.20241206
-
-
-
-# unclear why the following pins are necessary, but without them, versions dependent on sphinx>=5.0 are installed
-    sphinxcontrib-applehelp==1.0.4
-    sphinxcontrib-devhelp==1.0.2
-    sphinxcontrib-htmlhelp==2.0.1
-    sphinxcontrib-jsmath==1.0.1
-    sphinxcontrib-qthelp==1.0.3
-    sphinxcontrib-serializinghtml==1.1.5
-
     tox~=4.11.0
     types-psutil~=5.9.5
     types_requests~=2.28
     types-retry~=0.9.9.4
     types-setuptools~=68.1.0.0
     types-tqdm~=4.66.0
-    Jinja2<3.1
+
 
 [options.entry_points]
 # Put your entry point scripts here

--- a/src/pds/__init__.py
+++ b/src/pds/__init__.py
@@ -1,4 +1,2 @@
 # -*- coding: utf-8 -*-
 """PDS Namespace."""
-
-__import__("pkg_resources").declare_namespace(__name__)

--- a/src/pds/registrysweepers/__init__.py
+++ b/src/pds/registrysweepers/__init__.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
-"""My PDS Module."""
+"""PDS Registry Sweepers."""
+import importlib.resources
+
 import pds.registrysweepers.provenance
-import pkg_resources
 
-
-__version__ = pkg_resources.resource_string(__name__, "VERSION.txt").decode("utf-8").strip()
-
-
-# For future consideration:
-#
-# - Other metadata (__docformat__, __copyright__, etc.)
-# - N̶a̶m̶e̶s̶p̶a̶c̶e̶ ̶p̶a̶c̶k̶a̶g̶e̶s̶ we got this
+__version__ = VERSION = importlib.resources.files(__name__).joinpath("VERSION.txt").read_text().strip()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, docs, lint
+envlist = py313, docs, lint
 isolated_build = True
 
 [testenv]
@@ -10,7 +10,7 @@ commands = pytest
 [testenv:docs]
 deps = .[dev]
 whitelist_externals = python
-commands = python setup.py build_sphinx
+commands = sphinx-build -b html docs/source docs/build
 
 [testenv:lint]
 deps = pre-commit
@@ -19,6 +19,6 @@ commands=
 skip_install = true
 
 [testenv:dev]
-basepython = python3.9
+basepython = python3.13
 usedevelop = True
 deps = .[dev]


### PR DESCRIPTION
## 🗒️ Summary
Upgrade for Python 3.13. Specifically:

- Disable "black" because it's conflicting with reorder-python-imports
- Modernize Sphinx dependencies and configuration
- Replace 3.9 with 3.13 in .dockerignore, branch_cicd.yaml, .gitignore, tox.ini, and README.md
- Replace and/or remove boilerplate left from the template repository (feels like no one is filling this in! 😅)
- Replace pkg_resources with importlib.resources
- Take advantage of implicit namespaces
- Update Setuptools metadata for 3.13: changing python_requires and updating dev dependencies

## ⚙️ Test Data and/or Report

```console
$ tox
…
51 passed, 1 warning in 2.24s 
…
  py313: OK (4.11=setup[1.77]+cmd[2.34] seconds)
  docs: OK (1.76=setup[1.40]+cmd[0.35] seconds)
  lint: OK (2.31=setup[0.00]+cmd[2.31] seconds)
  congratulations :) (8.24 seconds)
```

## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/105