### PR TITLE
Add coverage testing and reporting to SonarQube Cloud

### DIFF
--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -79,6 +79,11 @@ jobs:
                     pypi_password: ${{secrets.TEST_PYPI_PASSWORD}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
             -
+                name: 🛏️ Upload Coverage
+                uses: SonarSource/sonarqube-scan-action@v5
+                env:
+                    SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
+            -
                 name: 💳 Docker Hub Identification
                 uses: docker/login-action@v2
                 with:

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ pip-selfcheck.json
 
 # Python testing artifacts
 .coverage
+coverage.xml
 htmlcov
 .tox/
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,3 @@
+sonar.projectKey=NASA-PDS_registry-sweepers
+sonar.organization=nasa-pds
+sonar.python.coverage.reportPaths=coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,42 @@
 [tox]
 envlist = py313, docs, lint
-isolated_build = True
+requires = tox>=4.6
 
 [testenv]
-deps = .[dev]
-allowlist_externals = pytest
-commands = pytest
+description = run tests
+basepython = python3.13
+package = wheel
+extras = dev
+usedevelop = true
+commands = pytest --cov=src --cov-report=xml {posargs}
 
 [testenv:docs]
-deps = .[dev]
-whitelist_externals = python
+description = build docs
+extras = dev
 commands = sphinx-build -b html docs/source docs/build
 
 [testenv:lint]
-deps = pre-commit
-commands=
-    python -m pre_commit run --color=always {posargs:--all}
+description = run linters
 skip_install = true
+deps = pre-commit
+commands = python -m pre_commit run --color=always {posargs:--all}
 
-[testenv:dev]
-basepython = python3.13
-usedevelop = True
-deps = .[dev]
+[coverage:run]
+source = src
+omit =
+    */tests/*
+    */test_*
+    */__pycache__/*
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+    class .*\bProtocol\):
+    @(abc\.)?abstractmethod


### PR DESCRIPTION
## 🗒️ Summary

Merge to add coverage testing and reporting to SonarQube Cloud


## ⚙️ Test Data and/or Report

```console
(.venv) bash-3.2$ ls -l coverage.xml 
-rw-r--r--  1 kelly  staff  72673 Oct  4 10:50 coverage.xml
(.venv) bash-3.2$ file coverage.xml 
coverage.xml: XML 1.0 document text, ASCII text
```

## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/104