### PR TITLE
Fix security vulnerability: Run Docker container as non-root user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,4 +57,8 @@ RUN apt-get autoremove && \
     apt-get remove --quiet --yes gcc python3-dev && \
     rm --force --recursive /var/lib/apt/lists/*
 
+# Create non-root user for security best practices
+RUN useradd --create-home --shell /bin/bash sweeper
+USER sweeper
+
 CMD ["/usr/local/bin/sweepers_driver.py"]


### PR DESCRIPTION
## Summary
- Addresses SonarCloud security hotspot by adding a dedicated non-root user to the Docker container
- Container now runs as 'sweeper' user instead of root, following principle of least privilege
- Reduces security risk if container or application is compromised

## Changes
- Added `RUN useradd --create-home --shell /bin/bash sweeper` to create dedicated user
- Added `USER sweeper` directive to switch from root before CMD execution
- No functional changes to application behavior

## Security Impact
Running as root violates the principle of least privilege. If an attacker exploits a vulnerability in the Python application or dependencies, they would gain root privileges within the container. This fix ensures attackers would only have limited user privileges, making container escape scenarios less dangerous.

## Testing
The application does not require root privileges to:
- Read/write to OpenSearch
- Perform metadata transformations
- Execute sweeper operations

The change is backward compatible and does not affect functionality.

## Related Issues
Closes #192