### PR TITLE
Fix per-batch log.info calls that clutter logs at INFO level

### DIFF
--- a/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
@@ -39,7 +39,7 @@ def get_online_resources() -> Dict[str, str]:
     rows = 2000
     start = 0
     while True:
-        log.info("pull online resource from solr, starting at %i", start)
+        log.debug("pull online resource from solr, starting at %i", start)
         response = requests.get(
             f"https://pds.nasa.gov/services/search/search?q=data_class:Resource&wt=json&qt=all&rows={rows}&start={start}"
         )
@@ -236,7 +236,7 @@ def dry_run(
             stats["seen_node_ids"].update(wrapper._seen_node_ids)
 
             if i % 1000 == 0 and i > 0:
-                log.info("Processed %d documents...", i)
+                log.debug("Processed %d documents...", i)
 
     except StopIteration:
         log.info("Finished processing all documents from Solr")

--- a/src/pds/registrysweepers/provenance/__init__.py
+++ b/src/pds/registrysweepers/provenance/__init__.py
@@ -77,7 +77,7 @@ log = logging.getLogger(__name__)
 
 def get_records_for_lids(client: OpenSearch, lids: Collection[PdsLid]) -> Iterable[ProvenanceRecord]:
     ids_str = get_ids_list_str(lids, 3)  # type: ignore
-    log.info(limit_log_length(f"Fetching docs and generating records for {len(lids)} LIDs: {ids_str}"))
+    log.debug(limit_log_length(f"Fetching docs and generating records for {len(lids)} LIDs: {ids_str}"))
 
     query = {
         "query": {

--- a/src/pds/registrysweepers/reindexer/main.py
+++ b/src/pds/registrysweepers/reindexer/main.py
@@ -199,7 +199,7 @@ def accumulate_missing_mappings(
 
             if mapping_missing and property_name not in missing_mapping_updates:
                 if canonical_type_is_defined:
-                    log.info(
+                    log.debug(
                         limit_log_length(
                             f'Property {property_name} will be updated to type "{canonical_type}" from data dictionary'
                         )
@@ -347,7 +347,7 @@ def run(
                 ),
             )
             for property, mapping_typename in missing_mappings.items():
-                log.info(
+                log.debug(
                     limit_log_length(
                         f"Updating index {products_index_name} with missing mapping ({property}, {mapping_typename})"
                     )


### PR DESCRIPTION
## 🗒️ Summary

Downgrade 5 per-batch/per-request `log.info` calls to `log.debug` across 3 files, so nucleus logs are clean at the default `INFO` level.

| File | Location | Call pattern |
|------|----------|-------------|
| `provenance/__init__.py` | `get_records_for_lids()` | Once per LID batch (batch_size=5000; fires ~200× for 1M LIDs) |
| `legacy_registry_sync/legacy_registry_sync.py` | `get_online_resources()` while loop | Once per Solr page |
| `legacy_registry_sync/legacy_registry_sync.py` | dry-run doc iteration | Every 1000 documents |
| `reindexer/main.py` | missing-mapping detection inner loop | Once per unique missing property |
| `reindexer/main.py` | mapping update loop | Once per missing mapping applied |

All one-per-run summary/status/result logs remain at `INFO` level.

🤖 This PR was developed with AI assistance (Claude Sonnet 4.6).

## ⚙️ Test Data and/or Report

All 115 existing unit tests pass (`pytest tests/ --override-ini="addopts="`). No behavior change — log level only.

## ♻️ Related Issues

- Closes #217
- Refs #207
