### PR TITLE
implement blocking poll for mapping creation in ensure_index_mapping()

### DIFF
--- a/src/pds/registrysweepers/utils/db/indexing.py
+++ b/src/pds/registrysweepers/utils/db/indexing.py
@@ -35,7 +35,7 @@ def _check_mapping(client: OpenSearch, index_name: str, property_name: str, expe
     Checks whether the mapping for a given property has propagated with the expected type.
     - Returns silently if the mapping is present and correct.
     - Raises UnexpectedMappingTypeError if the type is wrong.
-    - Raises MissingMappingError if the mapping does not yet exist..
+    - Raises MissingMappingError if the mapping does not yet exist.
     """
     existing_type = _get_existing_mapping_type(client, index_name, property_name)
 
@@ -75,7 +75,7 @@ def ensure_index_mapping(client: OpenSearch, index_name: str, property_name: str
         return
     except MissingMappingError:
         logger.info(
-            f"Mapping for '{property_name}' not yet present in index '{index_name}' - creating mapping with type {property_type}.",
+            f"Mapping for '{property_name}' not yet present in index '{index_name}' - creating mapping with type {property_type}."
         )
         client.indices.put_mapping(
             index=index_name,

--- a/src/pds/registrysweepers/utils/db/indexing.py
+++ b/src/pds/registrysweepers/utils/db/indexing.py
@@ -1,10 +1,85 @@
+import logging
+
+import retry
 from opensearchpy import OpenSearch
 
+logger = logging.getLogger(__name__)
 
-def ensure_index_mapping(client: OpenSearch, index_name: str, property_name: str, property_type: str):
+MAPPING_POLL_MAX_TRIES = 10
+MAPPING_POLL_DELAY_SECONDS = 1
+
+
+class UnexpectedMappingTypeError(RuntimeError):
+    pass
+
+
+class MissingMappingError(RuntimeError):
+    pass
+
+
+def _get_existing_mapping_type(client: OpenSearch, index_name: str, property_name: str) -> str | None:
     """
-    Provides an easy-to-use wrapper for ensuring the presence of a given property name/type in a given index.
-    N.B. This cannot change the type of a mapping, as modification/deletion is impossible in ES/OS.  If the mapping
-    already exists, matching type or not, the function will gracefully fail and log an HTTP400 error.
+    Returns the current mapped type for a given property, or None if the mapping does not yet exist.
     """
-    client.indices.put_mapping(index=index_name, body={"properties": {property_name: {"type": property_type}}})
+    response = client.indices.get_mapping(index=index_name)
+    existing_properties = (
+        response.get(index_name, {})
+        .get("mappings", {})
+        .get("properties", {})
+    )
+    return existing_properties.get(property_name, {}).get("type")
+
+
+def _check_mapping(client: OpenSearch, index_name: str, property_name: str, expected_property_type: str) -> None:
+    """
+    Checks whether the mapping for a given property has propagated with the expected type.
+    - Returns silently if the mapping is present and correct.
+    - Raises UnexpectedMappingTypeError if the type is wrong.
+    - Raises MissingMappingError if the mapping does not yet exist..
+    """
+    existing_type = _get_existing_mapping_type(client, index_name, property_name)
+
+    if existing_type == expected_property_type:
+        return
+    elif existing_type is None:
+        raise MissingMappingError(f"Mapping for '{property_name}' missing from index.")
+    else:
+        raise UnexpectedMappingTypeError(
+            f"Mapping for '{property_name}' in index '{index_name}' exists with type "
+            f"'{existing_type}', but expected '{expected_property_type}'. Cannot remap - manual reindexing to new index "
+            f"is necessary."
+        )
+
+
+@retry.retry(
+    exceptions=MissingMappingError,
+    tries=MAPPING_POLL_MAX_TRIES,
+    delay=MAPPING_POLL_DELAY_SECONDS,
+    logger=logger,
+)
+def _await_mapping_creation(client: OpenSearch, index_name: str, property_name: str, property_type: str):
+    _check_mapping(client, index_name, property_name, property_type)
+
+
+def ensure_index_mapping(client: OpenSearch, index_name: str, property_name: str, property_type: str) -> None:
+    """
+    Ensures a given property mapping exists with the expected type in the given index,
+    polling until the mapping is confirmed active or retries are exhausted.
+
+    Raises:
+        UnexpectedMappingTypeError: immediately, if the mapping exists with a conflicting type.
+        MissingMappingError: if the mapping fails to propagate within the retry budget.
+    """
+    try:
+        _check_mapping(client, index_name, property_name, property_type)
+        return
+    except MissingMappingError:
+        logger.info(
+            f"Mapping for '{property_name}' not yet present in index '{index_name}' - creating mapping with type {property_type}.",
+        )
+        client.indices.put_mapping(
+            index=index_name,
+            body={"properties": {property_name: {"type": property_type}}},
+        )
+
+    _await_mapping_creation(client, index_name, property_name, property_type)


### PR DESCRIPTION
this addresses a potential race condition where writes occur very quickly after the put_mapping() call

## 🗒️ Summary
Addresses a race condition noticed by @tloubrieu-jpl on MCP-DEV.

### 🤖 AI Assistance Disclosure
Claude Web used for initial implementation, followed by excision/rework of 90% of it because it likes biting me any time I get comfortable enough to trust it with something simple, end-to-end.

## ⚙️ Test Data and/or Report
Existing test cases are sufficient

## ♻️ Related Issues
fixes #220 

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [x] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [x] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [x] **SonarCloud:** Confirmed no new High or Critical security findings.
- [x] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [x] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [x] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).
