### PR TITLE
Remove repairkit looping behaviour. Revert temporary commit.

### DIFF
--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -8,7 +8,6 @@ be modules with this executable package.
 import collections
 import logging
 import re
-from time import sleep
 from typing import Dict
 from typing import Iterable
 from typing import Union
@@ -130,10 +129,6 @@ def run(
             index_name=resolve_multitenant_index_name(client, "registry"),
             bulk_chunk_max_update_count=update_max_chunk_size,
         )
-
-    #     dev sleep to discover test-ism - edunn 20260508
-        log.info('TEMPORARY: Sleeping five seconds to allow index to catch up')
-        sleep(5)
 
     log.info(limit_log_length("Repairkit sweeper processing complete!"))
 

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -8,6 +8,7 @@ be modules with this executable package.
 import collections
 import logging
 import re
+from time import sleep
 from typing import Dict
 from typing import Iterable
 from typing import Union
@@ -129,6 +130,10 @@ def run(
             index_name=resolve_multitenant_index_name(client, "registry"),
             bulk_chunk_max_update_count=update_max_chunk_size,
         )
+
+    #     dev sleep to discover test-ism - edunn 20260508
+        log.info('TEMPORARY: Sleeping five seconds to allow index to catch up')
+        sleep(5)
 
     log.info(limit_log_length("Repairkit sweeper processing complete!"))
 

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -106,6 +106,13 @@ def run(
     index_name = resolve_multitenant_index_name(client, "registry")
     update_max_chunk_size = 20000
 
+    ensure_index_mapping(
+        client,
+        resolve_multitenant_index_name(client, "registry"),
+        SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY,
+        "integer",
+    )
+
     #  TODO: Dev note edunn 20260508: Previously, the update generation would loop until fresh queries got no hits.
     #   This has been disabled as it was causing a race condition with test-scale data (68 documents)
     #   If it is desirable to avoid missing last-minute-loaded stragglers until the next sweepers run, this must be
@@ -121,12 +128,7 @@ def run(
         request_timeout_seconds=180,
     )
     updates = generate_updates(all_docs, SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY, SWEEPERS_REPAIRKIT_VERSION)
-    ensure_index_mapping(
-        client,
-        resolve_multitenant_index_name(client, "registry"),
-        SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY,
-        "integer",
-    )
+
     write_updated_docs(
         client,
         updates,

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -105,30 +105,34 @@ def run(
     # i.e. ATM and GEO
     index_name = resolve_multitenant_index_name(client, "registry")
     update_max_chunk_size = 20000
-    # todo: implement max_retries and/or comparison of count between loops to detect stalls or other problems
-    while get_query_hits_count(client, index_name, get_unprocessed_docs_query()) > 0:
-        all_docs = query_registry_db_with_search_after(
-            client,
-            index_name,
-            get_unprocessed_docs_query(),
-            {},
-            page_size=500,
-            limit=update_max_chunk_size,
-            request_timeout_seconds=180,
-        )
-        updates = generate_updates(all_docs, SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY, SWEEPERS_REPAIRKIT_VERSION)
-        ensure_index_mapping(
-            client,
-            resolve_multitenant_index_name(client, "registry"),
-            SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY,
-            "integer",
-        )
-        write_updated_docs(
-            client,
-            updates,
-            index_name=resolve_multitenant_index_name(client, "registry"),
-            bulk_chunk_max_update_count=update_max_chunk_size,
-        )
+
+    #  TODO: Dev note edunn 20260508: Previously, the update generation would loop until fresh queries got no hits.
+    #   This has been disabled as it was causing a race condition with test-scale data (68 documents)
+    #   If it is desirable to avoid missing last-minute-loaded stragglers until the next sweepers run, this must be
+    #   reimplemented
+
+    all_docs = query_registry_db_with_search_after(
+        client,
+        index_name,
+        get_unprocessed_docs_query(),
+        {},
+        page_size=500,
+        limit=update_max_chunk_size,
+        request_timeout_seconds=180,
+    )
+    updates = generate_updates(all_docs, SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY, SWEEPERS_REPAIRKIT_VERSION)
+    ensure_index_mapping(
+        client,
+        resolve_multitenant_index_name(client, "registry"),
+        SWEEPERS_REPAIRKIT_VERSION_METADATA_KEY,
+        "integer",
+    )
+    write_updated_docs(
+        client,
+        updates,
+        index_name=resolve_multitenant_index_name(client, "registry"),
+        bulk_chunk_max_update_count=update_max_chunk_size,
+    )
 
     log.info(limit_log_length("Repairkit sweeper processing complete!"))
 


### PR DESCRIPTION
## 🗒️ Summary
Per title

### 🤖 AI Assistance Disclosure
- [x] No AI assistance used
- [ ] AI used for light assistance (e.g., suggestions, refactoring, documentation help, minor edits)
- [ ] AI used for moderate content generation (AI generated some code or logic, but the developer authored or heavily revised the majority)
- [ ] AI generated substantial portions of this code

Estimated % of code influenced by AI: ___ %

## ⚙️ Test Data and/or Report
Existing tests suffice

## ♻️ Related Issues
Related to #222 
Related to #220 

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [ ] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).
