### PR TITLE
finicky linting issue

### DIFF
--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -57,7 +57,7 @@ log = logging.getLogger(__name__)
 
 
 def generate_updates(
-    docs: Iterable[Dict], repairkit_version_metadata_key: str, repairkit_version: int
+        docs: Iterable[Dict], repairkit_version_metadata_key: str, repairkit_version: int
 ) -> Iterable[Update]:
     """Lazily generate necessary Update objects for a collection of db documents"""
     repair_already_logged_to_error = False
@@ -84,9 +84,9 @@ def generate_updates(
 
 
 def run(
-    client: OpenSearch,
-    log_filepath: Union[str, None] = None,
-    log_level: int = logging.INFO,
+        client: OpenSearch,
+        log_filepath: Union[str, None] = None,
+        log_level: int = logging.INFO,
 ):
     configure_logging(filepath=log_filepath, log_level=log_level)
     log.info(limit_log_length(f"Starting repairkit v{SWEEPERS_REPAIRKIT_VERSION} sweeper processing..."))

--- a/src/pds/registrysweepers/repairkit/__init__.py
+++ b/src/pds/registrysweepers/repairkit/__init__.py
@@ -137,10 +137,6 @@ def run(
         bulk_chunk_max_update_count=update_max_chunk_size,
     )
 
-    #     dev sleep to discover test-ism - edunn 20260508
-        log.info('TEMPORARY: Sleeping five seconds to allow index to catch up')
-        sleep(5)
-
     log.info(limit_log_length("Repairkit sweeper processing complete!"))
 
 


### PR DESCRIPTION
## 🗒️ Summary
E999 linting issue detected in unstable delivery but not branch tests (will investigate separately)

### 🤖 AI Assistance Disclosure
- [x] No AI assistance used
- [ ] AI used for light assistance (e.g., suggestions, refactoring, documentation help, minor edits)
- [ ] AI used for moderate content generation (AI generated some code or logic, but the developer authored or heavily revised the majority)
- [ ] AI generated substantial portions of this code

Estimated % of code influenced by AI: ___ %

## ⚙️ Test Data and/or Report
n/a

## ♻️ Related Issues
related to #223 

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [ ] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).
