### PR TITLE
Add on-demand sweeper CLI: --only flag, console script, and operator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package provides supplementary metadata generation for registry documents, 
 #### [RepairKit](https://github.com/NASA-PDS/registry-sweepers/blob/main/src/pds/registrysweepers/repairkit/__init__.py)
 The repairkit sweeper applies idempotent transformations to targeted subsets of properties, for example ensuring that all properties expected to have array-like values are in fact arrays (as opposed to single-element arrays being flattened to strings during harvest).  Documents are processed based on whether their `ops:Provenance/ops:registry_sweepers_repairkit_version` metadata value is up-to-date relative to the sweeper codebase.
 
-> **Note:** RepairKit is currently disabled. It is not compatible with the current registry and requires refactoring before it can be executed. Passing `--repairkit` on the CLI will log a warning and skip it.
+> **Note:** RepairKit is currently disabled. It is not compatible with the current registry and requires refactoring before it can be executed.
 
 #### [Provenance](https://github.com/NASA-PDS/registry-sweepers/blob/main/src/pds/registrysweepers/provenance.py)
 The provenance sweeper generates metadata for linking each version-superseded product with the versioned product which supersedes it.  The value of the successor is stored in the `ops:Provenance/ops:superseded_by` property.  This property will not be set for the latest version of any product. All documents are processed, but db writes are optimised based on whether their `ops:Provenance/ops:registry_sweepers_provenance_version` metadata value is up-to-date relative to the sweeper codebase.

--- a/README.md
+++ b/README.md
@@ -73,23 +73,23 @@ The tool provides comprehensive statistics including:
 Use `pds-registry-sweepers` to run the sweepers from the command line.
 
 ```bash
-# Run the full default suite
+# Run the full default suite (provenance, ancestry, reindexer)
 pds-registry-sweepers
 
 # Run a single sweeper
-pds-registry-sweepers --ancestry
+pds-registry-sweepers --only ancestry
 
 # Run multiple specific sweepers
-pds-registry-sweepers --ancestry --provenance
+pds-registry-sweepers --only ancestry provenance
 
-# Override the target endpoint for a specific run
-pds-registry-sweepers --ancestry --endpoint https://your-domain.us-west-2.es.amazonaws.com
+# Run the legacy registry sync sweeper
+pds-registry-sweepers --only legacy-sync
 ```
 
 ### Sweeper selection
 
 - With no flags, the full default suite runs (provenance, ancestry, reindexer).
-- With one or more sweeper flags, only those sweepers run.
+- With `--only <name> [name ...]`, only the named sweeper(s) run. Available names: `provenance`, `ancestry`, `reindexer`, `legacy-sync`.
 
 ### Authentication and required environment variables
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,58 @@ The tool provides comprehensive statistics including:
 
 **Full synchronization** (Solr + OpenSearch) is available programmatically via the `run()` function but is not yet implemented as a console script option.
 
+## On-Demand Execution
+
+Use `pds-registry-sweepers` to run the sweepers from the command line.
+
+```bash
+# Run the full default suite
+pds-registry-sweepers
+
+# Run a single sweeper
+pds-registry-sweepers --only --repairkit
+
+# Run multiple specific sweepers
+pds-registry-sweepers --only --ancestry --provenance
+
+# Override the target endpoint for a specific run
+pds-registry-sweepers --only --ancestry --endpoint https://your-domain.us-west-2.es.amazonaws.com
+```
+
+### How `--only` works
+
+- Without `--only`, the default sweepers run.
+- With `--only`, default sweepers are skipped and only explicitly flagged sweepers run.
+
+### Authentication and required environment variables
+
+#### EC2 instance profile / IAM (AWS OpenSearch Service)
+
+Use this flow when running from an EC2 instance with an IAM profile attached.
+
+```bash
+export PROV_ENDPOINT=https://your-domain.us-west-2.es.amazonaws.com
+unset PROV_CREDENTIALS
+```
+
+- `PROV_ENDPOINT` is required.
+- Do not set `PROV_CREDENTIALS` for IAM auth.
+- Ensure the EC2 instance profile has permissions to access the target OpenSearch domain.
+
+#### Username/password auth (non-IAM OpenSearch)
+
+```bash
+export PROV_ENDPOINT=https://localhost:9200
+export PROV_CREDENTIALS='{"admin":"admin"}'
+```
+
+- `PROV_ENDPOINT` is required.
+- `PROV_CREDENTIALS` is required for this flow and must be a JSON object containing one username/password pair.
+
+### Non-production TLS usage
+
+For non-production environments with self-signed certificates, use `--insecure` to skip certificate verification.
+
 ## Developer Quickstart
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -118,7 +118,12 @@ export PROV_CREDENTIALS='{"admin":"admin"}'
 
 ### Non-production TLS usage
 
-For non-production environments with self-signed certificates, use `--insecure` to skip certificate verification.
+For non-production environments with self-signed certificates, set `DEV_MODE=1` to skip certificate verification.
+
+```bash
+export DEV_MODE=1
+pds-registry-sweepers
+```
 
 ## Developer Quickstart
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This package provides supplementary metadata generation for registry documents, 
 #### [RepairKit](https://github.com/NASA-PDS/registry-sweepers/blob/main/src/pds/registrysweepers/repairkit/__init__.py)
 The repairkit sweeper applies idempotent transformations to targeted subsets of properties, for example ensuring that all properties expected to have array-like values are in fact arrays (as opposed to single-element arrays being flattened to strings during harvest).  Documents are processed based on whether their `ops:Provenance/ops:registry_sweepers_repairkit_version` metadata value is up-to-date relative to the sweeper codebase.
 
+> **Note:** RepairKit is currently disabled. It is not compatible with the current registry and requires refactoring before it can be executed. Passing `--repairkit` on the CLI will log a warning and skip it.
+
 #### [Provenance](https://github.com/NASA-PDS/registry-sweepers/blob/main/src/pds/registrysweepers/provenance.py)
 The provenance sweeper generates metadata for linking each version-superseded product with the versioned product which supersedes it.  The value of the successor is stored in the `ops:Provenance/ops:superseded_by` property.  This property will not be set for the latest version of any product. All documents are processed, but db writes are optimised based on whether their `ops:Provenance/ops:registry_sweepers_provenance_version` metadata value is up-to-date relative to the sweeper codebase.
 
@@ -75,19 +77,19 @@ Use `pds-registry-sweepers` to run the sweepers from the command line.
 pds-registry-sweepers
 
 # Run a single sweeper
-pds-registry-sweepers --only --repairkit
+pds-registry-sweepers --ancestry
 
 # Run multiple specific sweepers
-pds-registry-sweepers --only --ancestry --provenance
+pds-registry-sweepers --ancestry --provenance
 
 # Override the target endpoint for a specific run
-pds-registry-sweepers --only --ancestry --endpoint https://your-domain.us-west-2.es.amazonaws.com
+pds-registry-sweepers --ancestry --endpoint https://your-domain.us-west-2.es.amazonaws.com
 ```
 
-### How `--only` works
+### Sweeper selection
 
-- Without `--only`, the default sweepers run.
-- With `--only`, default sweepers are skipped and only explicitly flagged sweepers run.
+- With no flags, the full default suite runs (provenance, ancestry, reindexer).
+- With one or more sweeper flags, only those sweepers run.
 
 ### Authentication and required environment variables
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ dev =
 [options.entry_points]
 # Put your entry point scripts here
 console_scripts =
+    pds-registry-sweepers = pds.registrysweepers.driver:run
     pds-legacy-registry-sync = pds.registrysweepers.legacy_registry_sync.legacy_registry_sync:main
 
 [options.packages.find]

--- a/src/pds/registrysweepers/driver.py
+++ b/src/pds/registrysweepers/driver.py
@@ -92,7 +92,11 @@ def _run_sweepers(sweepers: list):
             log_level=log_level,
         )
 
-    sweeper_descriptions = [inspect.getmodule(f).__name__ for f in sweepers]
+    def module_name(f: Callable) -> str:
+        mod = inspect.getmodule(f)
+        return mod.__name__ if mod is not None else repr(f)
+
+    sweeper_descriptions = [module_name(f) for f in sweepers]
     log.info(limit_log_length(f"Running sweepers: {sweeper_descriptions}"))
 
     total_execution_begin = datetime.now()
@@ -101,7 +105,7 @@ def _run_sweepers(sweepers: list):
     for sweeper in sweepers:
         sweeper_execution_begin = datetime.now()
         run_factory(sweeper)()
-        sweeper_name = inspect.getmodule(sweeper).__name__
+        sweeper_name = module_name(sweeper)
         sweeper_execution_duration_strs.append(
             f"{sweeper_name}: {get_human_readable_elapsed_since(sweeper_execution_begin)}"
         )

--- a/src/pds/registrysweepers/driver.py
+++ b/src/pds/registrysweepers/driver.py
@@ -101,12 +101,22 @@ def run():
 
     # define optional sweepers
     parser.add_argument("--legacy-sync", action="store_true")
+    parser.add_argument("--repairkit", action="store_true")
+    parser.add_argument("--provenance", action="store_true")
+    parser.add_argument("--ancestry", action="store_true")
+    parser.add_argument("--reindexer", action="store_true")
     parser.add_argument(
         "--only",
         action="store_true",
         help="Only run sweepers explicitly enabled via flags, skipping the default sweepers",
     )
-    optional_sweepers = {"legacy_sync": legacy_registry_sync.run}
+    additional_optional_sweepers = {"legacy_sync": legacy_registry_sync.run}
+    named_default_sweepers = {
+        "repairkit": repairkit.run,
+        "provenance": provenance.run,
+        "ancestry": ancestry.run,
+        "reindexer": reindexer.run,
+    }
 
     args = parser.parse_args()
 
@@ -119,7 +129,12 @@ def run():
 
     sweepers = [] if args.only else list(default_sweepers)
 
-    for option, sweeper in optional_sweepers.items():
+    if args.only:
+        for option, sweeper in named_default_sweepers.items():
+            if getattr(args, option):
+                sweepers.append(sweeper)
+
+    for option, sweeper in additional_optional_sweepers.items():
         if getattr(args, option):
             sweepers.append(sweeper)
 

--- a/src/pds/registrysweepers/driver.py
+++ b/src/pds/registrysweepers/driver.py
@@ -99,34 +99,28 @@ def run():
         description="sweeps the PDS registry with different routines meant to run regularly on the database",
     )
 
-    # define optional sweepers
     parser.add_argument("--legacy-sync", action="store_true")
     parser.add_argument("--repairkit", action="store_true")
     parser.add_argument("--provenance", action="store_true")
     parser.add_argument("--ancestry", action="store_true")
     parser.add_argument("--reindexer", action="store_true")
-    parser.add_argument(
-        "--only",
-        action="store_true",
-        help="Only run sweepers explicitly enabled via flags, skipping the default sweepers",
-    )
-    additional_optional_sweepers = {"legacy_sync": legacy_registry_sync.run}
-    named_default_sweepers = {
-        "repairkit": repairkit.run,
+
+    # Ordered map of flag name → sweeper function; repairkit excluded (requires refactoring for current registry)
+    selectable_sweepers = {
         "provenance": provenance.run,
         "ancestry": ancestry.run,
         "reindexer": reindexer.run,
+        "legacy_sync": legacy_registry_sync.run,
     }
 
-    args = parser.parse_args()
-
-    # Define default sweepers to be run here, in order of execution
-    # NOTE: repairkit is excluded - not compatible with current registry, requires refactoring
+    # Default execution order when no flags are provided
     default_sweepers = [
         provenance.run,
         ancestry.run,
         reindexer.run,
     ]
+
+    args = parser.parse_args()
 
     if args.repairkit:
         log.warning(
@@ -134,16 +128,9 @@ def run():
             "executed - skipping"
         )
 
-    sweepers = [] if args.only else list(default_sweepers)
-
-    if args.only:
-        for option, sweeper in named_default_sweepers.items():
-            if getattr(args, option) and sweeper is not repairkit.run:
-                sweepers.append(sweeper)
-
-    for option, sweeper in additional_optional_sweepers.items():
-        if getattr(args, option):
-            sweepers.append(sweeper)
+    any_flag_provided = args.repairkit or any(getattr(args, flag) for flag in selectable_sweepers)
+    explicit = [sweeper for flag, sweeper in selectable_sweepers.items() if getattr(args, flag)]
+    sweepers = explicit if any_flag_provided else default_sweepers
 
     sweeper_descriptions = [inspect.getmodule(f).__name__ for f in sweepers]
     log.info(limit_log_length(f"Running sweepers: {sweeper_descriptions}"))

--- a/src/pds/registrysweepers/driver.py
+++ b/src/pds/registrysweepers/driver.py
@@ -121,17 +121,24 @@ def run():
     args = parser.parse_args()
 
     # Define default sweepers to be run here, in order of execution
+    # NOTE: repairkit is excluded - not compatible with current registry, requires refactoring
     default_sweepers = [
         provenance.run,
         ancestry.run,
         reindexer.run,
     ]
 
+    if args.repairkit:
+        log.warning(
+            "RepairKit sweeper is not compatible with the current registry and requires refactoring before it can be "
+            "executed - skipping"
+        )
+
     sweepers = [] if args.only else list(default_sweepers)
 
     if args.only:
         for option, sweeper in named_default_sweepers.items():
-            if getattr(args, option):
+            if getattr(args, option) and sweeper is not repairkit.run:
                 sweepers.append(sweeper)
 
     for option, sweeper in additional_optional_sweepers.items():

--- a/src/pds/registrysweepers/driver.py
+++ b/src/pds/registrysweepers/driver.py
@@ -72,7 +72,7 @@ from pds.registrysweepers.utils.misc import is_dev_mode
 from pds.registrysweepers.utils.misc import limit_log_length
 
 
-def run():
+def _run_sweepers(sweepers: list):
     configure_logging(filepath=None, log_level=logging.INFO)
     log = logging.getLogger(__name__)
 
@@ -89,62 +89,18 @@ def run():
         return functools.partial(
             sweeper_f,
             client=get_opensearch_client_from_environment(verify_certs=True if not dev_mode else False),
-            # enable for development if required - not necessary in production
-            # log_filepath='registry-sweepers.log',
             log_level=log_level,
         )
-
-    parser = argparse.ArgumentParser(
-        prog="registry-sweepers",
-        description="sweeps the PDS registry with different routines meant to run regularly on the database",
-    )
-
-    parser.add_argument("--legacy-sync", action="store_true")
-    parser.add_argument("--repairkit", action="store_true")
-    parser.add_argument("--provenance", action="store_true")
-    parser.add_argument("--ancestry", action="store_true")
-    parser.add_argument("--reindexer", action="store_true")
-
-    # Ordered map of flag name → sweeper function; repairkit excluded (requires refactoring for current registry)
-    selectable_sweepers = {
-        "provenance": provenance.run,
-        "ancestry": ancestry.run,
-        "reindexer": reindexer.run,
-        "legacy_sync": legacy_registry_sync.run,
-    }
-
-    # Default execution order when no flags are provided
-    default_sweepers = [
-        provenance.run,
-        ancestry.run,
-        reindexer.run,
-    ]
-
-    args = parser.parse_args()
-
-    if args.repairkit:
-        log.warning(
-            "RepairKit sweeper is not compatible with the current registry and requires refactoring before it can be "
-            "executed - skipping"
-        )
-
-    any_flag_provided = args.repairkit or any(getattr(args, flag) for flag in selectable_sweepers)
-    explicit = [sweeper for flag, sweeper in selectable_sweepers.items() if getattr(args, flag)]
-    sweepers = explicit if any_flag_provided else default_sweepers
 
     sweeper_descriptions = [inspect.getmodule(f).__name__ for f in sweepers]
     log.info(limit_log_length(f"Running sweepers: {sweeper_descriptions}"))
 
     total_execution_begin = datetime.now()
-
     sweeper_execution_duration_strs = []
 
     for sweeper in sweepers:
         sweeper_execution_begin = datetime.now()
-        run_sweeper_f = run_factory(sweeper)
-
-        run_sweeper_f()
-
+        run_factory(sweeper)()
         sweeper_name = inspect.getmodule(sweeper).__name__
         sweeper_execution_duration_strs.append(
             f"{sweeper_name}: {get_human_readable_elapsed_since(sweeper_execution_begin)}"
@@ -156,3 +112,31 @@ def run():
             + "\n   ".join(sweeper_execution_duration_strs)
         )
     )
+
+
+SWEEPER_REGISTRY = {
+    "provenance": provenance.run,
+    "ancestry": ancestry.run,
+    "reindexer": reindexer.run,
+    "legacy-sync": legacy_registry_sync.run,
+}
+
+DEFAULT_SWEEPERS = ["provenance", "ancestry", "reindexer"]
+
+
+def run():
+    parser = argparse.ArgumentParser(
+        prog="registry-sweepers",
+        description="sweeps the PDS registry with different routines meant to run regularly on the database",
+    )
+    parser.add_argument(
+        "--only",
+        nargs="+",
+        metavar="SWEEPER",
+        choices=SWEEPER_REGISTRY.keys(),
+        help=f"Only run the specified sweeper(s). Choices: {', '.join(SWEEPER_REGISTRY.keys())}",
+    )
+    args = parser.parse_args()
+
+    names = args.only if args.only else DEFAULT_SWEEPERS
+    _run_sweepers([SWEEPER_REGISTRY[name] for name in names])

--- a/tests/pds/registrysweepers/test_driver.py
+++ b/tests/pds/registrysweepers/test_driver.py
@@ -35,16 +35,28 @@ def _run_driver_with_args(monkeypatch, args):
 def test_run_with_no_flags_runs_default_sweepers(monkeypatch):
     sweeper_calls = _run_driver_with_args(monkeypatch, [])
 
-    assert sweeper_calls == ["repairkit", "provenance", "ancestry", "reindexer"]
+    assert sweeper_calls == ["provenance", "ancestry", "reindexer"]
 
 
-def test_run_with_only_and_named_flag_runs_only_selected_default_sweeper(monkeypatch):
-    sweeper_calls = _run_driver_with_args(monkeypatch, ["--only", "--repairkit"])
+def test_run_with_named_flag_runs_only_that_sweeper(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, ["--ancestry"])
 
-    assert sweeper_calls == ["repairkit"]
+    assert sweeper_calls == ["ancestry"]
 
 
-def test_run_with_only_and_multiple_named_flags_runs_all_selected_default_sweepers(monkeypatch):
-    sweeper_calls = _run_driver_with_args(monkeypatch, ["--only", "--ancestry", "--provenance"])
+def test_run_with_multiple_named_flags_runs_only_those_sweepers(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, ["--ancestry", "--provenance"])
 
     assert sweeper_calls == ["provenance", "ancestry"]
+
+
+def test_run_with_repairkit_flag_skips_it(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, ["--repairkit"])
+
+    assert sweeper_calls == []
+
+
+def test_run_with_legacy_sync_flag_runs_it(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, ["--legacy-sync"])
+
+    assert sweeper_calls == ["legacy_sync"]

--- a/tests/pds/registrysweepers/test_driver.py
+++ b/tests/pds/registrysweepers/test_driver.py
@@ -20,11 +20,10 @@ def _run_driver_with_args(monkeypatch, args):
     monkeypatch.setattr(driver, "get_human_readable_elapsed_since", lambda *_: "0s")
     monkeypatch.setattr(driver, "limit_log_length", lambda text: text)
 
-    monkeypatch.setattr(driver.repairkit, "run", _make_sweeper("repairkit"))
-    monkeypatch.setattr(driver.provenance, "run", _make_sweeper("provenance"))
-    monkeypatch.setattr(driver.ancestry, "run", _make_sweeper("ancestry"))
-    monkeypatch.setattr(driver.reindexer, "run", _make_sweeper("reindexer"))
-    monkeypatch.setattr(driver.legacy_registry_sync, "run", _make_sweeper("legacy_sync"))
+    monkeypatch.setitem(driver.SWEEPER_REGISTRY, "provenance", _make_sweeper("provenance"))
+    monkeypatch.setitem(driver.SWEEPER_REGISTRY, "ancestry", _make_sweeper("ancestry"))
+    monkeypatch.setitem(driver.SWEEPER_REGISTRY, "reindexer", _make_sweeper("reindexer"))
+    monkeypatch.setitem(driver.SWEEPER_REGISTRY, "legacy-sync", _make_sweeper("legacy-sync"))
 
     monkeypatch.setattr(sys, "argv", ["registry-sweepers", *args])
     driver.run()
@@ -38,25 +37,19 @@ def test_run_with_no_flags_runs_default_sweepers(monkeypatch):
     assert sweeper_calls == ["provenance", "ancestry", "reindexer"]
 
 
-def test_run_with_named_flag_runs_only_that_sweeper(monkeypatch):
-    sweeper_calls = _run_driver_with_args(monkeypatch, ["--ancestry"])
+def test_run_only_single_sweeper(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, ["--only", "ancestry"])
 
     assert sweeper_calls == ["ancestry"]
 
 
-def test_run_with_multiple_named_flags_runs_only_those_sweepers(monkeypatch):
-    sweeper_calls = _run_driver_with_args(monkeypatch, ["--ancestry", "--provenance"])
+def test_run_only_multiple_sweepers(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, ["--only", "ancestry", "provenance"])
 
-    assert sweeper_calls == ["provenance", "ancestry"]
-
-
-def test_run_with_repairkit_flag_skips_it(monkeypatch):
-    sweeper_calls = _run_driver_with_args(monkeypatch, ["--repairkit"])
-
-    assert sweeper_calls == []
+    assert sweeper_calls == ["ancestry", "provenance"]
 
 
-def test_run_with_legacy_sync_flag_runs_it(monkeypatch):
-    sweeper_calls = _run_driver_with_args(monkeypatch, ["--legacy-sync"])
+def test_run_only_legacy_sync(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, ["--only", "legacy-sync"])
 
-    assert sweeper_calls == ["legacy_sync"]
+    assert sweeper_calls == ["legacy-sync"]

--- a/tests/pds/registrysweepers/test_driver.py
+++ b/tests/pds/registrysweepers/test_driver.py
@@ -1,0 +1,50 @@
+import logging
+import sys
+
+from pds.registrysweepers import driver
+
+
+def _run_driver_with_args(monkeypatch, args):
+    sweeper_calls = []
+
+    def _make_sweeper(name):
+        def _run(*, client, log_level):
+            sweeper_calls.append(name)
+
+        return _run
+
+    monkeypatch.setattr(driver, "configure_logging", lambda *args, **kwargs: None)
+    monkeypatch.setattr(driver, "parse_log_level", lambda *_: logging.INFO)
+    monkeypatch.setattr(driver, "get_opensearch_client_from_environment", lambda **kwargs: object())
+    monkeypatch.setattr(driver, "is_dev_mode", lambda: False)
+    monkeypatch.setattr(driver, "get_human_readable_elapsed_since", lambda *_: "0s")
+    monkeypatch.setattr(driver, "limit_log_length", lambda text: text)
+
+    monkeypatch.setattr(driver.repairkit, "run", _make_sweeper("repairkit"))
+    monkeypatch.setattr(driver.provenance, "run", _make_sweeper("provenance"))
+    monkeypatch.setattr(driver.ancestry, "run", _make_sweeper("ancestry"))
+    monkeypatch.setattr(driver.reindexer, "run", _make_sweeper("reindexer"))
+    monkeypatch.setattr(driver.legacy_registry_sync, "run", _make_sweeper("legacy_sync"))
+
+    monkeypatch.setattr(sys, "argv", ["registry-sweepers", *args])
+    driver.run()
+
+    return sweeper_calls
+
+
+def test_run_with_no_flags_runs_default_sweepers(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, [])
+
+    assert sweeper_calls == ["repairkit", "provenance", "ancestry", "reindexer"]
+
+
+def test_run_with_only_and_named_flag_runs_only_selected_default_sweeper(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, ["--only", "--repairkit"])
+
+    assert sweeper_calls == ["repairkit"]
+
+
+def test_run_with_only_and_multiple_named_flags_runs_all_selected_default_sweepers(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, ["--only", "--ancestry", "--provenance"])
+
+    assert sweeper_calls == ["provenance", "ancestry"]


### PR DESCRIPTION
Combines #245, #246, and #247 into a single PR.

## Summary

- **Console script entry point**: Adds `pds-registry-sweepers` to `setup.cfg` `console_scripts` so operators can invoke sweepers directly from PATH after `pip install`.
- **`--only <sweeper>...` flag**: Extends `driver.py` with `--only` accepting one or more sweeper names (`provenance`, `ancestry`, `reindexer`, `legacy-sync`). Without `--only`, the full default suite runs unchanged. Invalid names are rejected by argparse at parse time.
- **Operator documentation**: Adds an On-Demand Execution section to README covering full/selective invocations, `--only` semantics, EC2/IAM and username/password auth flows, and `DEV_MODE=1` for non-production TLS.

~~Named per-sweeper flags (`--repairkit`, `--provenance`, etc.) and a `--endpoint` CLI flag~~ — these were considered but dropped in favour of `--only <name>` which is simpler and more composable. Endpoint configuration remains via `PROV_ENDPOINT` env var only.

## Usage

```bash
# Run the full default suite (provenance, ancestry, reindexer)
pds-registry-sweepers

# Run a single sweeper
pds-registry-sweepers --only ancestry

# Run multiple specific sweepers
pds-registry-sweepers --only ancestry provenance

# Run the legacy registry sync sweeper
pds-registry-sweepers --only legacy-sync
```

## Test plan

- [x] `tox -e py313` — all 150 tests pass
- [x] `pytest tests/pds/registrysweepers/test_driver.py` — validates no-flags default, `--only ancestry`, `--only ancestry provenance`, `--only legacy-sync`
- [ ] `pip install -e . && pds-registry-sweepers --help` — confirms console script is installed and `--only` with choices appears

🤖 Generated with [Claude Code](https://claude.ai/claude-code)