### PR TITLE
Add pds-registry-sweepers entrypoint with --only <sweeper>... flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This package provides supplementary metadata generation for registry documents, 
 #### [RepairKit](https://github.com/NASA-PDS/registry-sweepers/blob/main/src/pds/registrysweepers/repairkit/__init__.py)
 The repairkit sweeper applies idempotent transformations to targeted subsets of properties, for example ensuring that all properties expected to have array-like values are in fact arrays (as opposed to single-element arrays being flattened to strings during harvest).  Documents are processed based on whether their `ops:Provenance/ops:registry_sweepers_repairkit_version` metadata value is up-to-date relative to the sweeper codebase.
 
+> **Note:** RepairKit is currently disabled. It is not compatible with the current registry and requires refactoring before it can be executed.
+
 #### [Provenance](https://github.com/NASA-PDS/registry-sweepers/blob/main/src/pds/registrysweepers/provenance.py)
 The provenance sweeper generates metadata for linking each version-superseded product with the versioned product which supersedes it.  The value of the successor is stored in the `ops:Provenance/ops:superseded_by` property.  This property will not be set for the latest version of any product. All documents are processed, but db writes are optimised based on whether their `ops:Provenance/ops:registry_sweepers_provenance_version` metadata value is up-to-date relative to the sweeper codebase.
 
@@ -66,6 +68,29 @@ The tool provides comprehensive statistics including:
 
 **Full synchronization** (Solr + OpenSearch) is available programmatically via the `run()` function but is not yet implemented as a console script option.
 
+## On-Demand Execution
+
+Use `pds-registry-sweepers` to run the sweepers from the command line.
+
+```bash
+# Run the full default suite (provenance, ancestry, reindexer)
+pds-registry-sweepers
+
+# Run a single sweeper
+pds-registry-sweepers --only ancestry
+
+# Run multiple specific sweepers
+pds-registry-sweepers --only ancestry provenance
+
+# Run the legacy registry sync sweeper
+pds-registry-sweepers --only legacy-sync
+```
+
+- With no flags, the full default suite runs: `provenance`, `ancestry`, `reindexer`.
+- With `--only <name> [name ...]`, only the named sweeper(s) run. Available names: `provenance`, `ancestry`, `reindexer`, `legacy-sync`.
+
+`PROV_ENDPOINT` and (for non-AWS OpenSearch) `PROV_CREDENTIALS` environment variables are required. See the Developer Quickstart section for details.
+
 ## Developer Quickstart
 
 ### Prerequisites
@@ -100,7 +125,7 @@ DEV_MODE=1      #disables host verification
 PYDEVD_USE_CYTHON=NO // disables Cython speedup extension
 ```
 
-With `--legacy-sync` option, the "registry" alias mapping all the discipline nodes indexes is required.
+With `--only legacy-sync`, the "registry" alias mapping all the discipline nodes indexes is required.
 
 Use the connection aliases found in the 'Connections' tab of the Engineering Node OpenSearch Domain on AWS.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ dev =
 [options.entry_points]
 # Put your entry point scripts here
 console_scripts =
+    pds-registry-sweepers = pds.registrysweepers.driver:run
     pds-legacy-registry-sync = pds.registrysweepers.legacy_registry_sync.legacy_registry_sync:main
 
 [options.packages.find]

--- a/src/pds/registrysweepers/driver.py
+++ b/src/pds/registrysweepers/driver.py
@@ -72,6 +72,16 @@ from pds.registrysweepers.utils.misc import is_dev_mode
 from pds.registrysweepers.utils.misc import limit_log_length
 
 
+SWEEPER_REGISTRY = {
+    "provenance": provenance.run,
+    "ancestry": ancestry.run,
+    "reindexer": reindexer.run,
+    "legacy-sync": legacy_registry_sync.run,
+}
+
+DEFAULT_SWEEPERS = ["provenance", "ancestry", "reindexer"]
+
+
 def run():
     configure_logging(filepath=None, log_level=logging.INFO)
     log = logging.getLogger(__name__)
@@ -94,36 +104,28 @@ def run():
             log_level=log_level,
         )
 
+    def module_name(f: Callable) -> str:
+        mod = inspect.getmodule(f)
+        return mod.__name__ if mod is not None else repr(f)
+
     parser = argparse.ArgumentParser(
         prog="registry-sweepers",
         description="sweeps the PDS registry with different routines meant to run regularly on the database",
     )
-
-    # define optional sweepers
-    parser.add_argument("--legacy-sync", action="store_true")
     parser.add_argument(
         "--only",
-        action="store_true",
-        help="Only run sweepers explicitly enabled via flags, skipping the default sweepers",
+        nargs="+",
+        metavar="SWEEPER",
+        choices=SWEEPER_REGISTRY.keys(),
+        help=f"Only run the specified sweeper(s). Choices: {', '.join(SWEEPER_REGISTRY.keys())}",
     )
-    optional_sweepers = {"legacy_sync": legacy_registry_sync.run}
 
     args = parser.parse_args()
 
-    # Define default sweepers to be run here, in order of execution
-    default_sweepers = [
-        provenance.run,
-        ancestry.run,
-        reindexer.run,
-    ]
+    names = args.only if args.only else DEFAULT_SWEEPERS
+    sweepers = [SWEEPER_REGISTRY[name] for name in names]
 
-    sweepers = [] if args.only else list(default_sweepers)
-
-    for option, sweeper in optional_sweepers.items():
-        if getattr(args, option):
-            sweepers.append(sweeper)
-
-    sweeper_descriptions = [inspect.getmodule(f).__name__ for f in sweepers]
+    sweeper_descriptions = [module_name(f) for f in sweepers]
     log.info(limit_log_length(f"Running sweepers: {sweeper_descriptions}"))
 
     total_execution_begin = datetime.now()
@@ -136,9 +138,8 @@ def run():
 
         run_sweeper_f()
 
-        sweeper_name = inspect.getmodule(sweeper).__name__
         sweeper_execution_duration_strs.append(
-            f"{sweeper_name}: {get_human_readable_elapsed_since(sweeper_execution_begin)}"
+            f"{module_name(sweeper)}: {get_human_readable_elapsed_since(sweeper_execution_begin)}"
         )
 
     log.info(

--- a/tests/pds/registrysweepers/test_driver.py
+++ b/tests/pds/registrysweepers/test_driver.py
@@ -1,0 +1,55 @@
+import logging
+import sys
+
+from pds.registrysweepers import driver
+
+
+def _run_driver_with_args(monkeypatch, args):
+    sweeper_calls = []
+
+    def _make_sweeper(name):
+        def _run(*, client, log_level):
+            sweeper_calls.append(name)
+
+        return _run
+
+    monkeypatch.setattr(driver, "configure_logging", lambda *args, **kwargs: None)
+    monkeypatch.setattr(driver, "parse_log_level", lambda *_: logging.INFO)
+    monkeypatch.setattr(driver, "get_opensearch_client_from_environment", lambda **kwargs: object())
+    monkeypatch.setattr(driver, "is_dev_mode", lambda: False)
+    monkeypatch.setattr(driver, "get_human_readable_elapsed_since", lambda *_: "0s")
+    monkeypatch.setattr(driver, "limit_log_length", lambda text: text)
+
+    monkeypatch.setitem(driver.SWEEPER_REGISTRY, "provenance", _make_sweeper("provenance"))
+    monkeypatch.setitem(driver.SWEEPER_REGISTRY, "ancestry", _make_sweeper("ancestry"))
+    monkeypatch.setitem(driver.SWEEPER_REGISTRY, "reindexer", _make_sweeper("reindexer"))
+    monkeypatch.setitem(driver.SWEEPER_REGISTRY, "legacy-sync", _make_sweeper("legacy-sync"))
+
+    monkeypatch.setattr(sys, "argv", ["registry-sweepers", *args])
+    driver.run()
+
+    return sweeper_calls
+
+
+def test_run_with_no_flags_runs_default_sweepers(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, [])
+
+    assert sweeper_calls == ["provenance", "ancestry", "reindexer"]
+
+
+def test_run_only_single_sweeper(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, ["--only", "ancestry"])
+
+    assert sweeper_calls == ["ancestry"]
+
+
+def test_run_only_multiple_sweepers(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, ["--only", "ancestry", "provenance"])
+
+    assert sweeper_calls == ["ancestry", "provenance"]
+
+
+def test_run_only_legacy_sync(monkeypatch):
+    sweeper_calls = _run_driver_with_args(monkeypatch, ["--only", "legacy-sync"])
+
+    assert sweeper_calls == ["legacy-sync"]


### PR DESCRIPTION
Replaces #249 with a minimal, focused diff off a clean `main` baseline.

## Summary

- **`setup.cfg`**: Add `pds-registry-sweepers` console script entrypoint so operators can invoke sweepers directly from PATH after `pip install`.
- **`driver.py`**: Replace the `--only` bool flag + `--legacy-sync` bool with `--only <name> [name ...]` accepting one or more sweeper names (`provenance`, `ancestry`, `reindexer`, `legacy-sync`). Adds `SWEEPER_REGISTRY` dict and `DEFAULT_SWEEPERS` list at module level. Guards `inspect.getmodule()` against `None` return (mypy).
- **`README.md`**: Add On-Demand Execution section with usage examples. Fix RepairKit disabled note. Update stale `--legacy-sync` flag reference to `--only legacy-sync`.
- **`tests/test_driver.py`**: New tests covering no-flags default execution, `--only` with a single sweeper, `--only` with multiple sweepers, and `--only legacy-sync`.

## Default behavior is unchanged

When `pds-registry-sweepers` is invoked with no flags — including in scheduled/automated runs — it executes exactly the same sweepers as before: **provenance, ancestry, reindexer**, in that order. RepairKit and legacy-sync are excluded from the default run, same as on `main`.

```python
DEFAULT_SWEEPERS = ["provenance", "ancestry", "reindexer"]
```

The `--only` flag is additive on top of this: it is only relevant when an operator wants to run a subset (or include `legacy-sync`) on demand.

## Usage

```bash
# Run the full default suite (provenance, ancestry, reindexer) — same as before
pds-registry-sweepers

# Run a single sweeper on demand
pds-registry-sweepers --only ancestry

# Run multiple specific sweepers on demand
pds-registry-sweepers --only ancestry provenance

# Run the legacy registry sync sweeper on demand
pds-registry-sweepers --only legacy-sync
```

## Test plan

- [x] `mypy src/` — no issues (49 source files)
- [x] `pytest` — 150 passed, 1 skipped (Python 3.13)
- [x] `tox -e py312` — 150 passed, 1 skipped
- [x] `tox -e py313` — 150 passed, 1 skipped
- [x] `tox -e docs` — OK
- [x] `test_run_with_no_flags_runs_default_sweepers` — verifies no-flags invocation runs exactly `[provenance, ancestry, reindexer]`
- [ ] `pip install -e . && pds-registry-sweepers --help` — confirm console script installed and `--only` choices visible

🤖 Generated with [Claude Code](https://claude.ai/claude-code)