### PR TITLE
Fix --force flag not skipping already-loaded documents in legacy-sync

### DIFF
--- a/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
@@ -91,8 +91,12 @@ def run(
 
     create_legacy_registry_index(es_conn=client)
 
-    prod_ids = get_already_loaded_lidvids(
-        product_classes=["Product_Context", "Product_Collection", "Product_Bundle"], es_conn=client
+    prod_ids = (
+        {}
+        if force
+        else get_already_loaded_lidvids(
+            product_classes=["Product_Context", "Product_Collection", "Product_Bundle"], es_conn=client
+        )
     )
 
     online_resources = get_online_resources()

--- a/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
@@ -91,13 +91,12 @@ def run(
 
     create_legacy_registry_index(es_conn=client)
 
-    prod_ids = (
-        {}
-        if force
-        else get_already_loaded_lidvids(
+    if force:
+        prod_ids = {}
+    else:
+        prod_ids = get_already_loaded_lidvids(
             product_classes=["Product_Context", "Product_Collection", "Product_Bundle"], es_conn=client
         )
-    )
 
     online_resources = get_online_resources()
 


### PR DESCRIPTION
## Summary

PR #226 added the `--force` flag but the implementation was incomplete: `force` only affected node re-derivation in `_get_node()` but never caused already-loaded documents to actually be reprocessed. `get_already_loaded_lidvids()` was called unconditionally in `run()` and the resulting `prod_ids` were always passed to `SolrOsWrapperIter`, so `--force` had no effect on which documents were written to OpenSearch.

**Fix:** Pass `prod_ids={}` (empty dict) to `SolrOsWrapperIter` when `force=True` in `run()`, so the already-loaded check is bypassed and all documents are reprocessed.

## Changes

- `run()` in `legacy_registry_sync.py`: skip `get_already_loaded_lidvids()` and pass empty `found_ids` when `force=True`
- Readability cleanup: simplified the `--force` conditional to an if/else

## Related Issues

Fixes #225 (reopened — was prematurely closed by #226 which only partially implemented the flag)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)