### PR TITLE
Fix --force flag not skipping already-loaded document check in legacy-sync

### DIFF
--- a/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
+++ b/src/pds/registrysweepers/legacy_registry_sync/legacy_registry_sync.py
@@ -91,9 +91,12 @@ def run(
 
     create_legacy_registry_index(es_conn=client)
 
-    prod_ids = get_already_loaded_lidvids(
-        product_classes=["Product_Context", "Product_Collection", "Product_Bundle"], es_conn=client
-    )
+    if force:
+        prod_ids = {}
+    else:
+        prod_ids = get_already_loaded_lidvids(
+            product_classes=["Product_Context", "Product_Collection", "Product_Bundle"], es_conn=client
+        )
 
     online_resources = get_online_resources()
 


### PR DESCRIPTION
## Summary

The `--force` flag was wired up to `_get_node()` for node re-derivation, but `get_already_loaded_lidvids()` was still called unconditionally in `run()`. As a result, `--force` had no effect on which documents were reprocessed — all documents that were previously loaded would continue to be treated as already-loaded.

**Fix:** When `force=True`, skip `get_already_loaded_lidvids()` and pass an empty dict as `found_ids` to `SolrOsWrapperIter`, so all documents from Solr are reprocessed regardless of their presence in the registry.

## Related Issues

Fixes #225

🤖 Generated with [Claude Code](https://claude.ai/claude-code)